### PR TITLE
let's get practical

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,1 +1,24 @@
-ocrd_kraken/.pylintrc
+[MASTER]
+extension-pkg-whitelist=lxml
+
+[MESSAGES CONTROL]
+disable =
+    missing-docstring,
+    too-many-arguments,
+    too-many-locals,
+    too-few-public-methods,
+    too-many-branches,
+    too-many-statements,
+    too-many-nested-blocks,
+    too-many-instance-attributes,
+    no-else-return,
+    line-too-long,
+    bad-continuation,
+    useless-object-inheritance,
+    ungrouped-imports
+
+# allow indented whitespace (as required by interpreter):
+no-space-check=empty-line
+
+# allow non-snake-case identifiers:
+good-names=x,y,n,i,j

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,5 @@ deps:
 # pip install -e .
 install:
 	pip install -e .
+
+.PHONY: help deps install

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,29 @@ help:
 	@echo ""
 	@echo "  Targets"
 	@echo ""
-	@echo "    deps     pip install -r requirements.txt"
-	@echo "    install  pip install -e ."
+	@echo "    deps       pip install -r requirements.txt"
+	@echo "    deps-test  pip install -r requirements_test.txt"
+	@echo ""
+	@echo "    install    pip install -e ."
+	@echo "    test       python -m pytest test"
 
 # END-EVAL
 
-# pip install -r requirements.txt
 deps:
 	pip install -r requirements.txt
 
-# pip install -e .
+deps-test:
+	pip install -r requirements_test.txt
+
 install:
 	pip install -e .
 
-.PHONY: help deps install
+test: test/assets
+	test -f model_dta_test.weights.h5 -a -f model_dta_test.config.pkl || keraslm-rate train -m model_dta_test.weights.h5 -c model_dta_test.config.pkl test/assets/*.txt
+	keraslm-rate test -m model_dta_test.weights.h5 -c model_dta_test.config.pkl test/assets/*.txt
+	python -m pytest test $(PYTEST_ARGS)
+
+test/assets:
+	test/prepare_gt.bash $@
+
+.PHONY: help deps deps-test install test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,194 @@
 # ocrd_keraslm
-Simple character-based language model using keras
+    Simple character-based language model using Keras
+
+
+## Introduction
+
+This is a tool for statistical _language modelling_ (predicting text from context) with recurrent neural networks. It models probabilities not on the word level but the UTF-8 _byte level_. That way, there is no fixed vocabulary of known/allowed words/characters, and no word segmentation ambiguity. 
+
+### Architecture
+
+The model consists of:
+1. no embedding layer: input bytes are represented as unit vectors ("one-hot coding") in 256 dimensions, in windows of a number `length` of bytes,
+2. a number `depth` of hidden layers, each with a number `width` of hidden recurrent units of _LSTM cells_ (Long Short-term Memory),
+3. a softmax output layer, returning a probability for each possible value of the next byte, respectively.
+
+This is implemented in [Keras](https://keras.io) with [Tensorflow](https://www.tensorflow.org/) as backend. It automatically uses a fast CUDA-optimized LSTM implementation if available (Nividia GPU and Tensorflow installation with GPU support, see below), both in learning and in prediction phase. 
+
+
+### Modes of operation
+
+Notably, this model (by default) runs _statefully_, i.e. by implicitly passing hidden state from one window (batch) to the next. That way, the context available for predictions can be arbitrarily long (above `length`, e.g. the complete document up to that point), or short (below `length`, e.g. at the start of a text). (However, this is a passive perspective above `length`, because errors are never back-propagated any further in time during gradient-descent training.) 
+
+Besides stateful mode, the model can also be run _incrementally_, i.e. by explicitly passing hidden state from the caller. That way, multiple alternative hypotheses can be processed together. This is used for generation (sampling from the model) and alternative decoding (finding the best path through a sequence of alternatives).
+
+
+## Installation
+
+Required Ubuntu packages:
+
+* Python (``python`` or ``python3``)
+* pip (``python-pip`` or ``python3-pip``)
+* virtualenv (``python-virtualenv`` or ``python3-virtualenv``)
+
+Create and activate a virtualenv as usual.
+
+If you need a custom version of ``keras`` or ``tensorflow`` (like [GPU support](https://www.tensorflow.org/install/install_sources)), install them via `pip` now.
+
+To install Python dependencies and this module, then do:
+```shell
+make deps install
+```
+Which is the equivalent of:
+```shell
+pip install -r requirements.txt
+pip install -e .
+```
+
+Useful environment variables are:
+- ``TF_CPP_MIN_LOG_LEVEL`` (set to `1` to suppress most of Tensorflow's messages
+- ``CUDA_VISIBLE_DEVICES`` (set empty to force CPU even in a GPU installation)
+
+
+## Usage
+
+This packages has two user interfaces:
+
+### command line interface `keraslm-rate`
+
+To be used with string arguments and plain-text files.
+
+```shell
+Usage: keraslm-rate [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  apply     get individual probabilities from language model
+  generate  sample characters from language model
+  test      get overall perplexity from language model
+  train     train a language model
+```
+
+Examples:
+```shell
+keraslm-rate train --width 64 --depth 4 --length 256 --model model_dta_64_4_256.weights.h5 --config model_dta_64_4_256.config.pkl dta_komplett_2017-09-01/txt/*.tcf.txt
+keraslm-rate generate -m model_dta_64_4_256.weights.h5 -c model_dta_64_4_256.config.pkl --number 6 "für die Wiſſen"
+keraslm-rate apply -m model_dta_64_4_256.weights.h5 -c model_dta_64_4_256.config.pkl "so schädlich ist es Borkickheile zu pflanzen"
+keraslm-rate test -m model_dta_64_4_256.weights.h5 -c model_dta_64_4_256.config.pkl dta_komplett_2017-09-01/txt/grimm_*.tcf.txt
+```
+
+### [OCR-D processor](https://github.com/OCR-D/core) interface `ocrd-keraslm-rate`
+
+To be used with [PageXML](https://www.primaresearch.org/tools/PAGELibraries) documents in an [OCR-D](https://github.com/OCR-D/spec/) annotation workflow.
+
+```json
+  "tools": {
+    "ocrd-keraslm-rate": {
+      "executable": "ocrd-keraslm-rate",
+      "categories": [
+        "Text recognition and optimization"
+      ],
+      "steps": [
+        "recognition/text-recognition"
+      ],
+      "description": "Rate each element of the text with a byte-level LSTM language model in Keras",
+      "parameters": {
+        "weight_file": {
+          "type": "string",
+          "description": "path of h5 weight file for model trained with keraslm",
+          "required": true
+        },
+        "config_file": {
+          "type": "string",
+          "description": "path of pkl config file for model trained with keraslm",
+          "required": true
+        },
+        "textequiv_level": {
+          "type": "string",
+          "enum": ["region", "line", "word", "glyph"],
+          "default": "glyph",
+          "description": "PAGE XML hierarchy level to evaluate TextEquiv sequences on"
+        },
+        "add_space_glyphs": {
+          "type": "boolean",
+          "description": "whether to insert whitespace and newline as pseudo-glyphs in result (at glyph level)",
+          "default": false
+        },
+        "alternative_decoding": {
+          "type": "boolean",
+          "description": "whether to process all TextEquiv alternatives, finding the best path via beam search, and delete each non-best alternative",
+          "default": true
+        },
+        "beam_width": {
+          "type": "number",
+          "format": "integer",
+          "description": "maximum number of best partial paths to consider during search with alternative_decoding",
+          "default": 100
+        }
+      }
+    }
+  }
+```
+
+Examples:
+```shell
+make deps-test # installs ocrd_tesserocr
+make test/assets # downloads GT, imports PageXML, builds workspaces
+ocrd workspace clone -a -l kant_aufklaerung_1784/mets.xml ws1
+cd ws1
+ocrd-tesserocr-segment-region -I OCR-D-IMG -O OCR-D-SEG-BLOCK -p <(echo "{}")
+ocrd-tesserocr-segment-line -I OCR-D-SEG-BLOCK -O OCR-D-SEG-LINE -p <(echo "{}")
+cat <<EOF > param-tess-word.json
+{
+  "textequiv_level" : "word",
+  "model" : "Fraktur"
+}
+EOF
+cat <<EOF > param-tess-glyph.json
+{
+  "textequiv_level" : "glyph",
+  "model" : "deu-frak"
+}
+EOF
+ocrd-tesserocr-recognize -I OCR-D-SEG-LINE -O OCR-D-OCR-TESS-WORD -p param-tess-word.json
+ocrd-tesserocr-recognize -I OCR-D-SEG-LINE -O OCR-D-OCR-TESS-GLYPH -p param-tess-glyph.json
+cat <<EOF > param-lm-word-1.json
+{
+    "weight_file": "model_dta_64_4_256.weights.h5",
+    "config_file": "model_dta_64_4_256.config.pkl",
+    "textequiv_level": "word",
+    "add_space_glyphs": false,
+    "alternative_decoding": false
+}
+EOF
+cat <<EOF > param-lm-glyph-all.json
+{
+    "weight_file": "model_dta_64_4_256.weights.h5",
+    "config_file": "model_dta_64_4_256.config.pkl",
+    "textequiv_level": "glyph",
+    "add_space_glyphs": true,
+    "alternative_decoding": true,
+    "beam_width": 10
+}
+EOF
+ocrd-keraslm-rate -I OCR-D-OCR-TESS-WORD -O OCR-D-OCR-LM-WORD -p param-lm-word-1.json # get confidences and perplexity
+ocrd-keraslm-rate -I OCR-D-OCR-TESS-GLYPH -O OCR-D-OCR-LM-GLYPH -p param-lm-glyph-all.json # also get best path
+```
+
+## Testing
+
+```shell
+make deps-test test
+```
+Which is the equivalent of:
+```shell
+pip install -r requirements_test.txt
+test -e test/assets || test/prepare_gt.bash test/assets
+test -f model_dta_test.weights.h5 -a -f model_dta_test.config.pkl || keraslm-rate train -m model_dta_test.weights.h5 -c model_dta_test.config.pkl test/assets/*.txt
+keraslm-rate test -m model_dta_test.weights.h5 -c model_dta_test.config.pkl test/assets/*.txt
+python -m pytest test $(PYTEST_ARGS)
+```
+
+Set `PYTEST_ARGS="-s --verbose"` to see log output (`-s`) and individual test results (`--verbose`).

--- a/ocrd_keraslm/lib/__init__.py
+++ b/ocrd_keraslm/lib/__init__.py
@@ -1,1 +1,1 @@
-from .rating import Rater
+from .rating import Rater, Node

--- a/ocrd_keraslm/lib/rating.py
+++ b/ocrd_keraslm/lib/rating.py
@@ -1,5 +1,7 @@
+from keras.callbacks import Callback
 import click, numpy, pickle
-from math import log, exp, ceil
+from random import shuffle
+from math import log, exp, ceil, floor
 
 class Rater(object):
     
@@ -9,7 +11,7 @@ class Rater(object):
         '''
         
         self.clear()
-
+    
     def clear(self):
         '''
         Resets rater.
@@ -18,62 +20,116 @@ class Rater(object):
         from keras.models import Sequential
 
         self.model = Sequential()
-        self.status = 0
-        self.length = 15
-        self.variable_length = False # also train on partially filled windows
-        self.minibatch_size = 128
-        self.validation_split = 0.2
-    
-    def train(self, training_data, width, depth, length):
-        '''
-        Trains an RNN language model on `training_data` files (UTF-8 byte sequences).
-        '''
+        self.status = 0 # trained?
         
+        self.length = 0 # will be overwritten by CLI for train / by load model for rate/test
+        self.width = 0 # will be overwritten by CLI for train / by load model for rate/test
+        self.depth = 0 # will be overwritten by CLI for train / by load model for rate/test
+        self.length = 0 # will be overwritten by CLI for train / by load model for rate/test
+        
+        self.variable_length = False # also train on partially filled windows
+        self.stateful = False # keep states across batches within one text
+        self.minibatch_size = 128 # will be overwritten by length if stateful
+        self.validation_split = 0.2 # fraction of training data to use for validation (generalization control)
+    
+    def configure(self):
         from keras.layers import Dense
         from keras.layers import LSTM, CuDNNLSTM
-        from keras.callbacks import EarlyStopping
         from keras import backend as K
+        
+        #
+        # model
+        length = None if self.variable_length else self.length
+        # automatically switch to CuDNNLSTM if CUDA GPU is available:
+        has_cuda = K.backend() == 'tensorflow' and K.tensorflow_backend._get_available_gpus()
+        print('using', 'GPU' if has_cuda else 'CPU', 'LSTM implementation to compile',
+              'stateful' if self.stateful else 'stateless', 'model of depth',
+              self.depth, 'width', self.width,'length', self.length)
+        lstm = CuDNNLSTM if has_cuda else LSTM
+        for i in range(self.depth):
+            args = {'return_sequences': (i+1 < self.depth), 'stateful': self.stateful}
+            if not has_cuda:
+                args['recurrent_activation'] = 'sigmoid' # instead of default 'hard_sigmoid' which deviates from CuDNNLSTM
+            if i == 0:
+                if self.stateful:
+                    args['batch_input_shape'] = (self.minibatch_size, length, 256) # batch size must be constant
+                else:
+                    args['input_shape'] = (length, 256) # batch size not fixed (e.g. different between training and prediction)
+            self.model.add(lstm(self.width,
+                                **args))
+        self.model.add(Dense(256, activation='softmax'))
+        self.model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['accuracy'])
+    
+    def train(self, data, width, depth, length):
+        '''
+        Trains an RNN language model on `data` files (UTF-8 byte sequences).
+        '''
+        from keras.callbacks import EarlyStopping, ModelCheckpoint
         
         if self.status != 0:
             self.clear()
-        self.length = length # now from CLI
-
-        total_size = 0
-        max_size = 0
-        chars = set([])
-        with click.progressbar(training_data) as bar:
-            for f in bar:
+        self.width = width
+        self.depth = depth
+        self.length = length
+        if self.stateful:
+            self.minibatch_size = self.length # make sure states are consistent with windows after 1 minibatch
+        
+        self.configure()
+        
+        data = list(data)
+        shuffle(data) # random order of files (because generators cannot shuffle within files)
+        if self.stateful: # we must split file-wise in stateful mode
+            steps = 1 # really necessary?
+            split = ceil(len(data)*self.validation_split) # split position in randomized file list
+            training_data, validation_data = data[:-split], data[-split:] # reserve last files for validation
+            for f in validation_data:
+                print ('using input', f.name, 'for validation only')
+            training_epoch_size = 0
+            for f in training_data:
                 text = f.read()
-                size = len(text)
-                total_size += size
-                max_size = max(max_size, size)
-
-        steps = 3
-        epoch_size = total_size/steps/self.minibatch_size
-        training_epoch_size = ceil(epoch_size*(1-self.validation_split))
-        validation_epoch_size = ceil(epoch_size*self.validation_split)
-        if self.variable_length:
-            training_epoch_size *= ceil((self.length-1)/steps) # training data augmented with partial windows
+                training_epoch_size += floor(len(text)/steps/self.minibatch_size)
+            validation_epoch_size = 0
+            for f in validation_data:
+                text = f.read()
+                validation_epoch_size += floor(len(text)/steps/self.minibatch_size)
+            reset_cb = ResetStatesCallback()
+        else: # we can split window by window in stateless mode
+            steps = 3
+            total_size = 0
+            max_size = 0
+            with click.progressbar(data) as bar:
+                for f in bar:
+                    text = f.read()
+                    size = len(text)
+                    total_size += size
+                    max_size = max(max_size, size)
+            epoch_size = total_size/steps/self.minibatch_size
+            training_epoch_size = ceil(epoch_size*(1-self.validation_split))
+            validation_epoch_size = ceil(epoch_size*self.validation_split)
+            if self.variable_length:
+                training_epoch_size *= ceil((self.length-1)/steps) # training data augmented with partial windows
+            validation_data, training_data = data, data # same data, different generators (see below)
+            split = numpy.random.uniform(0,1, (ceil(max_size/steps),)) # reserve split fraction at random positions
         
         #
         # data preparation
-
-        split = numpy.random.uniform(0,1, (ceil(max_size/steps),))
         def gen_data(files, train):
-            # encode
             while True:
                 for f in files:
                     f.seek(0)
+                    if self.stateful:
+                        reset_cb.reset()
                     text = f.read()
+                    # encode
                     sequences = []
                     next_chars = []
                     for i in range(0, len(text) - self.length, steps):
-                        if (split[int(i/steps)]<self.validation_split) == train:
-                            continue
+                        if not self.stateful and (split[int(i/steps)]<self.validation_split) == train:
+                            continue # data shared between training and split: belongs to other generator
                         sequences.append(text[i: i + self.length])
                         next_chars.append(text[i + self.length])
-                        if (len(sequences) % self.minibatch_size == 0 or 
-                            i + steps > len(text) - self.length): # last minibatch
+                        if (len(sequences) % self.minibatch_size == 0 # next minibatch full
+                            or i + steps > len(text) - self.length): # last minibatch
                             # vectorization
                             x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
                             y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(bytearray(next_chars), dtype=numpy.uint8)]
@@ -86,38 +142,24 @@ class Rater(object):
                             sequences = []
                             next_chars = []
         
-        #
-        # model
-        
-        # define model
-        # width = 128 # now from CLI
-        # depth = 2 # now from CLI
-        length = None if self.variable_length else self.length
-        # automatically switch to CuDNNLSTM if CUDA GPU is available:
-        has_cuda = K.backend() == 'tensorflow' and K.tensorflow_backend._get_available_gpus()
-        print('using', 'GPU' if has_cuda else 'CPU', 'LSTM implementation to compile model of depth',depth,'width',width,'length',self.length)
-        lstm = CuDNNLSTM if has_cuda else LSTM # todo: do not use save/load_model but save_weights/load_weights (so GPU and CPU-only hosts can share models) with extra pickle file for configuration
-        for i in range(depth):
-            args = {'return_sequences': (i+1<depth)}
-            if not has_cuda:
-                args['activation'] = 'sigmoid' # instead of default 'hard_sigmoid' which deviates from CuDNNLSTM
-            if i == 0:
-                args['input_shape'] = (length, 256)
-            self.model.add(lstm(width,
-                                **args))
-        self.model.add(Dense(256, activation='softmax'))
-        self.model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['accuracy'])
         
         # fit model
-        early_stopping = EarlyStopping(monitor='val_loss', patience=1, verbose=1)
-        self.model.fit_generator(gen_data(training_data, True), steps_per_epoch=training_epoch_size, epochs=100, verbose=1, validation_data=gen_data(training_data, False), validation_steps=validation_epoch_size, callbacks=[early_stopping]) # todo: make iterator thread-safe and use_multiprocesing=True
+        callbacks = [EarlyStopping(monitor='val_loss', patience=1, verbose=1),
+                     ModelCheckpoint('model_last.weights.h5', monitor='val_loss', # to be able to replay long epochs (crash/overfitting)
+                                     save_best_only=True, save_weights_only=True, mode='min')]
+        if self.stateful:
+            callbacks.append(reset_cb)
+        self.model.fit_generator(gen_data(training_data, True), steps_per_epoch=training_epoch_size, epochs=100, 
+                                 validation_data=gen_data(validation_data, False), validation_steps=validation_epoch_size,
+                                 verbose=1, callbacks=callbacks) # todo: make iterator thread-safe and use_multiprocesing=True
         
         # set state
         self.status = 1
     
     def save(self, filename):
         '''
-        Saves model.
+        Saves model into `filename`.
+        (Cannot preserve weights across CPU/GPU implementations or input shape configurations.)
         '''
         
         if self.status:
@@ -125,11 +167,12 @@ class Rater(object):
     
     def load(self, filename):
         '''
-        Loads model.
+        Loads model from `filename`.
+        (Cannot preserve weights across CPU/GPU implementations or input shape configurations.)
         '''
-
+        
         from keras.models import load_model
-
+        
         # load model
         self.model = load_model(filename)
         # get parameters from model which are relevant to preprocessing
@@ -145,13 +188,44 @@ class Rater(object):
             print('overriding variable length from saved model (representation might be suboptimal)')
             self.variable_length = True
         self.status = 1
+
+    def save2(self, configfilename, weightfilename):
+        '''
+        Saves model configuration into `configfilename` and model weights into `weightfilename`.
+        (This preserves weights across CPU/GPU implementations or input shape configurations.)
+        '''
+        
+        if self.status:
+            config = {'width': self.width, 'depth': self.depth, 'length': self.length, 'stateful': self.stateful, 'variable_length': self.variable_length}
+            pickle.dump(config, open(configfilename, mode='wb'))
+            self.model.save_weights(weightfilename)
+    
+    def load2(self, configfilename, weightfilename):
+        '''
+        Loads model configuration from `configfilename`, compiles a new model from that, then loads weights into it from `weightfilename`.
+        (This preserves weights across CPU/GPU implementations or input shape configurations.)
+        '''
+        
+        if self.status != 0:
+            self.clear()
+        config = pickle.load(open(configfilename, mode='rb'))
+        self.width = config['width']
+        self.depth = config['depth']
+        self.length = config['length']
+        self.stateful = config['stateful']
+        self.variable_length = config['variable_length']
+        self.configure()
+        
+        self.model.load_weights(weightfilename)
+        
+        self.status = 1
     
     def rate(self, text):
         '''
         Calculates probabilities (individually) and perplexity (accumulated)
         of the character sequence in `text` according to the current model.
         '''
-
+        
         # perplexity calculation is a lot slower that way than via tensor metric, cf. test()
         # todo: allow graph input (by pruning via history clustering or push forward algorithm;
         #                       or by aggregating lattice input)
@@ -161,12 +235,13 @@ class Rater(object):
             entropy = 0
             result = []
             length = 0
-            for c in text:
+            self.model.reset_states()
+            for c in text: # could be single characters or words later-on (when applying incrementally or from graph)
                 p = 1.0
                 for b in c.encode("utf-8"):
                     x_input = x[:,x.any(axis=2)[0]] if self.variable_length else x
                     if x_input.shape[1] > 0: # to prevent length 0 input
-                        pred = dict(enumerate(self.model.predict(x_input, verbose=0).tolist()[0]))
+                        pred = dict(enumerate(self.model.predict(x_input, batch_size=1, verbose=0).tolist()[0]))
                         entropy -= log(pred[b], 2)
                         length += 1
                         p *= pred[b]
@@ -182,7 +257,13 @@ class Rater(object):
         Calculates the perplexity of the character sequences in all `test_data` files
         (UTF-8 byte sequences) according to the current model.
         '''
-
+        
+        # todo: Since Keras does not allow callbacks within evaluate() / evaluate_generator() / test_loop(),
+        #       we cannot reset_states() between input files as we do in train().
+        #       Thus we should evaluate each file individually, reset in between, and accumulate losses.
+        #       But this looks awkward, since we get N progress bars instead of 1, in contrast to training.
+        #       Perhaps the overall error introduced into stateful models by not resetting is not that high
+        #       after all?
         total_size = 0
         with click.progressbar(test_data) as bar:
             for f in bar:
@@ -191,7 +272,7 @@ class Rater(object):
                 total_size += size
         steps = 1
         epoch_size = ceil(total_size/self.minibatch_size)
-
+        
         # data preparation
         def gen_data(files):
             # encode
@@ -218,4 +299,27 @@ class Rater(object):
             return exp(loss)
         else:
             return 0
-        
+
+class ResetStatesCallback(Callback):
+    '''Callback to be called by `fit_generator()` or even `evaluate_generator()`:
+
+       do `model.reset_states()` whenever generator sees EOF (on_batch_begin with self.eof),
+       and between training and validation (on_batch_end with batch>=steps_per_epoch-1)
+    '''
+    def __init__(self):
+        self.eof = False
+    
+    def reset(self):
+        self.eof = True
+    
+    def on_batch_begin(self, batch, logs={}):
+        if self.eof:
+            # between training files
+            self.model.reset_states()
+            self.eof = False
+    
+    def on_batch_end(self, batch, logs={}):
+        if (self.params['do_validation'] and batch >= self.params['steps']-1):
+            # in fit_generator just before evaluate_generator
+            self.model.reset_states()
+

--- a/ocrd_keraslm/lib/rating.py
+++ b/ocrd_keraslm/lib/rating.py
@@ -1,9 +1,3 @@
-from keras.utils import to_categorical
-from keras.models import Sequential, load_model
-from keras.layers import Dense
-from keras.layers import LSTM
-from keras.callbacks import EarlyStopping
-
 import click, numpy, pickle
 from math import log, exp, ceil
 
@@ -21,18 +15,28 @@ class Rater(object):
         Resets rater.
         '''
         
+        from keras.models import Sequential
+
         self.model = Sequential()
         self.status = 0
-        self.length = 5
+        self.length = 15
+        self.variable_length = False # also train on partially filled windows
         self.minibatch_size = 128
         self.validation_split = 0.2
     
-    def train(self, training_data):
+    def train(self, training_data, width, depth, length):
         '''
         Trains an RNN language model on `training_data` files (UTF-8 byte sequences).
         '''
+        
+        from keras.layers import Dense
+        from keras.layers import LSTM, CuDNNLSTM
+        from keras.callbacks import EarlyStopping
+        from keras import backend as K
+        
         if self.status != 0:
             self.clear()
+        self.length = length # now from CLI
 
         total_size = 0
         max_size = 0
@@ -48,6 +52,8 @@ class Rater(object):
         epoch_size = total_size/steps/self.minibatch_size
         training_epoch_size = ceil(epoch_size*(1-self.validation_split))
         validation_epoch_size = ceil(epoch_size*self.validation_split)
+        if self.variable_length:
+            training_epoch_size *= ceil((self.length-1)/steps) # training data augmented with partial windows
         
         #
         # data preparation
@@ -72,15 +78,33 @@ class Rater(object):
                             x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
                             y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(bytearray(next_chars), dtype=numpy.uint8)]
                             yield (x,y)
+                            if train and self.variable_length: # also train on partial windows?
+                                for j in range(1,self.length-1, steps):
+                                    #x[:, 0:j, :] = False # complete batch gets erased by sublength from the left to simulate running in with zero padding as in rate()
+                                    #yield (x,y)
+                                    yield (x[:,-j:,:],y) # complete batch gets shortened to sublength from the right to simulate running in with short sequences in rate()
                             sequences = []
                             next_chars = []
         
         #
         # model
         
-        # define model # todo: automatically switch to CuDNNLSTM if CUDA GPU is available
-        self.model.add(LSTM(128, input_shape=(self.length, 256), return_sequences=True))
-        self.model.add(LSTM(128))
+        # define model
+        # width = 128 # now from CLI
+        # depth = 2 # now from CLI
+        length = None if self.variable_length else self.length
+        # automatically switch to CuDNNLSTM if CUDA GPU is available:
+        has_cuda = K.backend() == 'tensorflow' and K.tensorflow_backend._get_available_gpus()
+        print('using', 'GPU' if has_cuda else 'CPU', 'LSTM implementation to compile model of depth',depth,'width',width,'length',self.length)
+        lstm = CuDNNLSTM if has_cuda else LSTM # todo: do not use save/load_model but save_weights/load_weights (so GPU and CPU-only hosts can share models) with extra pickle file for configuration
+        for i in range(depth):
+            args = {'return_sequences': (i+1<depth)}
+            if not has_cuda:
+                args['activation'] = 'sigmoid' # instead of default 'hard_sigmoid' which deviates from CuDNNLSTM
+            if i == 0:
+                args['input_shape'] = (length, 256)
+            self.model.add(lstm(width,
+                                **args))
         self.model.add(Dense(256, activation='softmax'))
         self.model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['accuracy'])
         
@@ -91,21 +115,35 @@ class Rater(object):
         # set state
         self.status = 1
     
-    def save(self, prefix):
+    def save(self, filename):
         '''
         Saves model.
         '''
         
         if self.status:
-            self.model.save(u"%s.h5" % prefix)
+            self.model.save(filename)
     
-    def load(self, model):
+    def load(self, filename):
         '''
         Loads model.
         '''
-        
+
+        from keras.models import load_model
+
         # load model
-        self.model = load_model(model)
+        self.model = load_model(filename)
+        # get parameters from model which are relevant to preprocessing
+        batch_input_shape = self.model.get_config()[0]['config']['batch_input_shape']
+        if batch_input_shape[0] and batch_input_shape[0] != self.minibatch_size:
+            print('overriding minibatch_size %d by %d from saved model' % (self.minibatch_size, batch_input_shape[0]))
+            self.minibatch_size = batch_input_shape[0]
+        if batch_input_shape[1] and batch_input_shape[1] != self.length:
+            print('overriding length %d by %d from saved model' % (self.length, batch_input_shape[1]))
+            self.length = batch_input_shape[1]
+            self.variable_length = False
+        if not batch_input_shape[1] and not self.variable_length:
+            print('overriding variable length from saved model (representation might be suboptimal)')
+            self.variable_length = True
         self.status = 1
     
     def rate(self, text):
@@ -119,19 +157,21 @@ class Rater(object):
         #                       or by aggregating lattice input)
         # todo: make incremental
         if self.status:
-            x = numpy.zeros((1, self.length, 256))
+            x = numpy.zeros((1, self.length, 256), dtype=numpy.bool)
             entropy = 0
             result = []
             length = 0
             for c in text:
                 p = 1.0
                 for b in c.encode("utf-8"):
-                    pred = dict(enumerate(self.model.predict(x, verbose=0).tolist()[0]))
-                    entropy -= log(pred[b], 2)
-                    length += 1
-                    p *= pred[b]
+                    x_input = x[:,x.any(axis=2)[0]] if self.variable_length else x
+                    if x_input.shape[1] > 0: # to prevent length 0 input
+                        pred = dict(enumerate(self.model.predict(x_input, verbose=0).tolist()[0]))
+                        entropy -= log(pred[b], 2)
+                        length += 1
+                        p *= pred[b]
                     x = numpy.roll(x, -1, axis=1) # left-shifted by 1
-                    x[0,-1] = numpy.eye(256)[b] # one-hot vector for b in last pos
+                    x[0,-1] = numpy.eye(256, dtype=numpy.bool)[b] # one-hot vector for b in last pos
                 result.append((c, p))
             return result, pow(2.0, entropy/length)
         else:

--- a/ocrd_keraslm/lib/rating.py
+++ b/ocrd_keraslm/lib/rating.py
@@ -3,46 +3,46 @@ from keras.models import Sequential, load_model
 from keras.layers import Dense
 from keras.layers import LSTM
 from keras.callbacks import EarlyStopping
-from keras.preprocessing.sequence import pad_sequences
 
 import click, numpy, pickle
+from math import log
 
 class Rater(object):
-
+    
     def __init__(self):
         '''
         The constructor.
         '''
-
+        
         self.clear()
-
+    
     def clear(self):
         '''
         Resets rater.
         '''
-
+        
         self.model = Sequential()
         self.status = 0
         self.length = 5
-
+    
     def train(self, training_data):
         '''
         Trains an RNN model.
         '''
         if self.status != 0:
             self.clear()
-
+        
         #
         # mapping
         chars = sorted(list(set(training_data)))
         c_i = dict((c, i) for i, c in enumerate(chars))
         i_c = dict((i, c) for i, c in enumerate(chars))
         self.mapping = (c_i, i_c)
-
-
+        
+        
         #
         # data preparation
-
+        
         # encode
         step = 3
         sequences = []
@@ -51,7 +51,7 @@ class Rater(object):
             for i in bar:
                 sequences.append(training_data[i: i + self.length])
                 next_chars.append(training_data[i + self.length])
-
+        
         # vectorization
         x = numpy.zeros((len(sequences), self.length, len(self.mapping[0])), dtype=numpy.bool)
         y = numpy.zeros((len(sequences), len(self.mapping[0])), dtype=numpy.bool)
@@ -60,22 +60,22 @@ class Rater(object):
                 for t, char in enumerate(sequence):
                     x[i, t, c_i[char]] = 1
                     y[i, c_i[next_chars[i]]] = 1
-
+        
         #
         # model
-
+        
         # define model
         self.model.add(LSTM(128, input_shape=(5, len(self.mapping[0]))))
         self.model.add(Dense(len(self.mapping[0]), activation='softmax'))
         self.model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['accuracy'])
-
+        
         # fit model
         early_stopping = EarlyStopping(monitor='val_loss', patience=1, verbose=1)
         self.model.fit(x, y, batch_size=128, epochs=100, verbose=2, validation_split=0.2, callbacks=[early_stopping])
-
+        
         # set state
         self.status = 1
-
+    
     def save(self, prefix):
         '''
         Saves model and mapping.
@@ -84,34 +84,37 @@ class Rater(object):
         if self.status:
             self.model.save(u"%s.h5" % prefix)
             pickle.dump(self.mapping, open(u"%s.map" % prefix, mode='wb'))
-
+    
     def load(self, mapping, model):
         '''
         Loads model and mapping.
         '''
-
+        
         # load model
         self.model = load_model(model)
         self.mapping = pickle.load(open(mapping, mode="rb"))
         self.status = 1
-
+    
     def rate(self, text):
         '''
-        Rates the characters in text according to the model.
+        Calculates probabilities (individually) and perplexity (accumulated) 
+        of the characters in given text according to the model.
+        
+        Returns a list of character-probability tuples, and the perplexity
         '''
-
+        
         if self.status:
-            encoded_buffer = []
+            x = numpy.zeros((1, self.length, len(self.mapping[0])))
+            entropy = 0
             result = []
             for c in text:
-                x = numpy.zeros((1, self.length, len(self.mapping[0])))
-                encoded = pad_sequences([encoded_buffer], maxlen=self.length, truncating='pre')
-                for t, i in enumerate(encoded[0]):
-                    x[0, t, i] = 1.
                 pred = dict(enumerate(self.model.predict(x, verbose=0).tolist()[0]))
                 i = self.mapping[0][c]
                 result.append((c, pred[i]))
-                encoded_buffer.append(i)
-            return result
+                entropy -= log(pred[i], 2)
+                x = numpy.roll(x, -1, axis=1) # left-shifted by 1
+                x[0,-1] = numpy.eye(len(self.mapping[0]))[i] # one-hot vector for c in last pos
+            return result, pow(2.0, entropy/len(text))
         else:
-            return []
+            return [], 0
+    

--- a/ocrd_keraslm/lib/rating.py
+++ b/ocrd_keraslm/lib/rating.py
@@ -2,6 +2,7 @@ from keras.utils import to_categorical
 from keras.models import Sequential, load_model
 from keras.layers import Dense
 from keras.layers import LSTM
+from keras.callbacks import EarlyStopping
 from keras.preprocessing.sequence import pad_sequences
 
 import click, numpy, pickle
@@ -69,7 +70,8 @@ class Rater(object):
         self.model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['accuracy'])
 
         # fit model
-        self.model.fit(x, y, batch_size=128, epochs=100, verbose=2)
+        early_stopping = EarlyStopping(monitor='val_loss', patience=1, verbose=1)
+        self.model.fit(x, y, batch_size=128, epochs=100, verbose=2, validation_split=0.2, callbacks=[early_stopping])
 
         # set state
         self.status = 1

--- a/ocrd_keraslm/lib/rating.py
+++ b/ocrd_keraslm/lib/rating.py
@@ -1,7 +1,10 @@
-from keras.callbacks import Callback
-import click, numpy, pickle, codecs
+import pickle
+import codecs
 from random import shuffle
-from math import log, exp, ceil, floor
+from math import log, exp, ceil
+import click
+import numpy
+from keras.callbacks import Callback
 
 class Rater(object):
     '''A character-level RNN language model for rating text.
@@ -10,32 +13,29 @@ class Rater(object):
     (LSTM) language model on the (UTF-8) byte level. The model's
     topology (layers depth, per-layer width, window length) can
     be controlled before training.
-
+    
     To be used by stand-alone CLI (`scripts.train` for training,
     `scripts.apply` for prediction, `scripts.test` for evaluation),
-    or OCR-D processing (`wrapper.ocrd_keraslm_rate`). 
-
+    or OCR-D processing (`wrapper.ocrd_keraslm_rate`).
+    
     Interfaces:
     - `Rater.train`/`scripts.train` : file handles of byte sequences
     - `Rater.test`/`scripts.test` : file handles of byte sequences
     - `Rater.rate`/`scripts.apply` : character string
     - `Rater.rate_once`/`wrapper.ocrd_keraslm_rate` : character string
-    - `Rater.rate_single`/`scripts.generate` or `wrapper.ocrd_keraslm_rate` : alternative list of bytes and states
+    - `Rater.rate_single`/`scripts.generate` or `wrapper.ocrd_keraslm_rate` :
+      alternative list of bytes and states
     '''
     
     def __init__(self):
-        self.clear()
-    
-    def clear(self):
         '''Reset model and set all parameters to their defaults.'''
         
         self.model = None
         self.status = 0 # empty / compiled / trained?
         
-        self.length = 0 # will be overwritten by CLI for train / by load model for rate/test
-        self.width = 0 # will be overwritten by CLI for train / by load model for rate/test
-        self.depth = 0 # will be overwritten by CLI for train / by load model for rate/test
-        self.length = 0 # will be overwritten by CLI for train / by load model for rate/test
+        self.width = 0 # will be overwritten by CLI for train() / by load_config for rate()/test()
+        self.depth = 0 # will be overwritten by CLI for train() / by load_config for rate()/test()
+        self.length = 0 # will be overwritten by CLI for train() / by load_config for rate()/test()
         
         self.variable_length = False # also train on partially filled windows
         self.stateful = True # keep states across batches within one text (implicit state transfer)
@@ -50,7 +50,7 @@ class Rater(object):
         from keras.layers import LSTM, CuDNNLSTM
         from keras import backend as K
         from keras.models import Model
-
+        
         length = None if self.variable_length else self.length
         # automatically switch to CuDNNLSTM if CUDA GPU is available:
         has_cuda = K.backend() == 'tensorflow' and K.tensorflow_backend._get_available_gpus()
@@ -78,19 +78,22 @@ class Rater(object):
             if self.incremental:
                 # incremental prediction needs additional inputs and outputs for state (h,c):
                 states = [Input(**states_input_args), Input(**states_input_args)]
+                layer = lstm(self.width, return_state=True, **args)
                 model_states_input.extend(states)
-                model_output, state_h, state_c = lstm(self.width, return_state = True, **args)(model_output, initial_state = states)
+                model_output, state_h, state_c = layer(model_output, initial_state=states)
                 model_states_output.extend([state_h, state_c])
             else:
-                model_output = lstm(self.width, **args)(model_output)
+                layer = lstm(self.width, **args)
+                model_output = layer(model_output)
         if self.stateful:
-            model_output = TimeDistributed(Dense(256, activation='softmax'))(model_output)
+            layer = TimeDistributed(Dense(256, activation='softmax'))
         else:
-            model_output = Dense(256, activation='softmax')(model_output)
+            layer = Dense(256, activation='softmax')
+        model_output = layer(model_output)
         if self.incremental:
             self.model = Model([model_input] + model_states_input, [model_output] + model_states_output)
         else:
-            self.model = Model(model_input, model_output)            
+            self.model = Model(model_input, model_output)
         self.model.compile(loss='categorical_crossentropy', optimizer='adam', metrics=['accuracy'])
         
         self.status = 1
@@ -99,21 +102,20 @@ class Rater(object):
         '''Train model on text files.
         
         Pass the UTF-8 byte sequences in all `data` files to the loop
-        training model weights with stochastic gradient descent. 
+        training model weights with stochastic gradient descent.
         It will open file by file, repeating over the complete set (epoch)
         as long as validation error does not increase in between (early stopping).
         Validate on a random fraction of the file set automatically separated before.
         (Data are split by window/file in stateless/stateful mode.)
-
+        
         If `val_data` is given, then do not split, but use those files
         for validation instead (regardless of mode).
         '''
-        from os.path import exists
         from keras.callbacks import EarlyStopping, ModelCheckpoint
         
         assert self.status > 0 # incremental training is allowed
-        assert self.incremental == False # no explicit state transfer
-
+        assert self.incremental is False # no explicit state transfer
+        
         data = list(data)
         shuffle(data) # random order of files (because generators cannot shuffle within files)
         if self.stateful: # we must split file-wise in stateful mode
@@ -124,15 +126,15 @@ class Rater(object):
             else:
                 split = ceil(len(data)*self.validation_split) # split position in randomized file list
                 training_data, validation_data = data[:-split], data[-split:] # reserve last files for validation
-            for f in validation_data:
-                print ('using input', f.name, 'for validation only')
+            for file in validation_data:
+                print('using input', file.name, 'for validation only')
             training_epoch_size = 0
-            for f in training_data:
-                text = f.read()
+            for file in training_data:
+                text = file.read()
                 training_epoch_size += ceil((len(text)-self.length)/steps/self.minibatch_size)
             validation_epoch_size = 0
-            for f in validation_data:
-                text = f.read()
+            for file in validation_data:
+                text = file.read()
                 validation_epoch_size += ceil((len(text)-self.length)/steps/self.minibatch_size)
             split = None
             reset_cb = ResetStatesCallback()
@@ -140,17 +142,17 @@ class Rater(object):
             steps = 3
             total_size = 0
             max_size = 0
-            with click.progressbar(data) as bar:
-                for f in bar:
-                    text = f.read()
+            with click.progressbar(data) as pbar:
+                for file in pbar:
+                    text = file.read()
                     size = len(text)
                     total_size += size - self.length
                     max_size = max(max_size, size)
             if val_data:
                 training_epoch_size = ceil(total_size/steps/self.minibatch_size)
-                with click.progressbar(val_data) as bar:
-                    for f in bar:
-                        text = f.read()
+                with click.progressbar(val_data) as pbar:
+                    for file in pbar:
+                        text = file.read()
                         size = len(text)
                         total_size += size - self.length
                 validation_epoch_size = ceil(total_size/steps/self.minibatch_size)
@@ -162,7 +164,7 @@ class Rater(object):
                 training_epoch_size = ceil(epoch_size*(1-self.validation_split))
                 validation_epoch_size = ceil(epoch_size*self.validation_split)
                 validation_data, training_data = data, data # same data, different generators (see below)
-                split = numpy.random.uniform(0,1, (ceil(max_size/steps),)) # reserve split fraction at random positions
+                split = numpy.random.uniform(0, 1, (ceil(max_size/steps),)) # reserve split fraction at random positions
             if self.variable_length:
                 training_epoch_size *= ceil((self.length-1)/steps) # training data augmented with partial windows
         
@@ -170,36 +172,38 @@ class Rater(object):
         # data preparation
         def gen_data(files, train):
             while True:
-                for f in files:
-                    f.seek(0)
+                for file in files:
+                    file.seek(0)
                     if self.stateful:
-                        reset_cb.reset(f.name)
-                    text = f.read()
+                        reset_cb.reset(file.name)
+                    text = file.read()
                     # encode
                     sequences = []
                     next_chars = []
                     for i in range(0, len(text) - self.length, steps):
-                        if split and (split[int(i/steps)]<self.validation_split) == train:
+                        if split and (split[int(i/steps)] < self.validation_split) == train:
                             continue # data shared between training and split: belongs to other generator
                         sequences.append(text[i: i + self.length])
                         if self.stateful:
                             next_chars.append(text[i+1: i+1 + self.length])
                         else:
                             next_chars.append(text[i + self.length])
-                        if (len(sequences) % self.minibatch_size == 0 # next minibatch full
-                            or i + steps >= len(text) - self.length): # last minibatch: partially filled batch
+                        if (len(sequences) % self.minibatch_size == 0 or # next minibatch full
+                                i + steps >= len(text) - self.length): # last minibatch: partially filled batch
                             # vectorization
-                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
+                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, sequences)), dtype=numpy.uint8)]
                             if self.stateful:
-                                y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,next_chars)), dtype=numpy.uint8)]
+                                y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, next_chars)), dtype=numpy.uint8)]
                             else:
                                 y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(bytearray(next_chars), dtype=numpy.uint8)]
-                            yield (x,y)
+                            yield (x, y)
                             if train and self.variable_length: # also train on partial windows?
-                                for j in range(1,self.length-1, steps):
-                                    #x[:, 0:j, :] = False # complete batch gets erased by sublength from the left to simulate running in with zero padding as in rate()
-                                    #yield (x,y)
-                                    yield (x[:,-j:,:],y) # complete batch gets shortened to sublength from the right to simulate running in with short sequences in rate()
+                                for j in range(1, self.length-1, steps):
+                                    # erase complete batch by sublength from the left to simulate running in with zero padding as in rate():
+                                    # x[:, 0:j, :] = False
+                                    # yield (x, y)
+                                    # shorten complete batch to sublength from the right to simulate running in with short sequences in rate():
+                                    yield (x[:, -j:, :], y)
                             sequences = []
                             next_chars = []
         
@@ -210,9 +214,10 @@ class Rater(object):
                                      save_best_only=True, save_weights_only=True, mode='min')]
         if self.stateful:
             callbacks.append(reset_cb)
-        self.model.fit_generator(gen_data(training_data, True), steps_per_epoch=training_epoch_size, epochs=100, 
+        # todo: make iterator thread-safe and then use_multiprocesing=True
+        self.model.fit_generator(gen_data(training_data, True), steps_per_epoch=training_epoch_size, epochs=100,
                                  validation_data=gen_data(validation_data, False), validation_steps=validation_epoch_size,
-                                 verbose=1, callbacks=callbacks) # todo: make iterator thread-safe and use_multiprocesing=True
+                                 verbose=1, callbacks=callbacks)
         
         # set state
         self.status = 2
@@ -274,8 +279,7 @@ class Rater(object):
         Load model configuration from `configfilename`.
         '''
         
-        if self.status > 0:
-            self.clear()
+        assert self.status == 0
         config = pickle.load(open(configfilename, mode='rb'))
         self.width = config['width']
         self.depth = config['depth']
@@ -307,39 +311,39 @@ class Rater(object):
         # prediction calculation is a lot slower that way than via batched generator, cf. rate_once() / test()
         # perplexity calculation is a lot slower that way than via tensor metric, cf. test()
         assert self.status > 1
-        assert self.incremental == False # no explicit state transfer
+        assert self.incremental is False # no explicit state transfer
         x = numpy.zeros((1, self.length, 256), dtype=numpy.bool)
         entropy = 0
         result = []
         length = 0
         self.model.reset_states()
-        for c in text:
-            p = 1.0
-            for b in c.encode("utf-8"):
-                x_input = x[:,x.any(axis=2)[0]] if self.variable_length else x
+        for char in text:
+            prob = 1.0
+            for char_byte in char.encode("utf-8"):
+                x_input = x[:, x.any(axis=2)[0]] if self.variable_length else x
                 if x_input.shape[1] > 0: # to prevent length 0 input
                     output = self.model.predict_on_batch(x_input).tolist()
                     pred = dict(enumerate(output[0][0] if self.stateful else output[0]))
-                    entropy -= log(pred[b], 2)
+                    entropy -= log(pred[char_byte], 2)
                     length += 1
-                    p *= pred[b]
+                    prob *= pred[char_byte]
                 x = numpy.roll(x, -1, axis=1) # left-shifted by 1
-                x[0,-1] = numpy.eye(256, dtype=numpy.bool)[b] # one-hot vector for b in last pos
-            result.append((c, p))
+                x[0, -1] = numpy.eye(256, dtype=numpy.bool)[char_byte] # one-hot vector for b in last pos
+            result.append((char, prob))
         return result, pow(2.0, entropy/length)
 
     def rate_single(self, candidates, initial_states):
         '''Predict probability from model, passing initial and final state.
-
-        Calculate the output probability distribution for a single input byte 
-        incrementally according to the current model. Do so in parallel for 
-        any number of hypotheses (i.e. batch size), identified by list position: 
-        For `candidates` hypotheses with their `initial_states`, return a tuple of 
+        
+        Calculate the output probability distribution for a single input byte
+        incrementally according to the current model. Do so in parallel for
+        any number of hypotheses (i.e. batch size), identified by list position:
+        For `candidates` hypotheses with their `initial_states`, return a tuple of
         their probabilities and their final states (for the next run).
         If any of `initial_states` is None, it is treated like reset (zero states).
-
+        
         Return a list of probability arrays and of final states.
-
+        
         (To be called by an adapter tracking history paths and input alternatives,
          combining them up to a maximum number of best running candidates, i.e. beam.
          See `scripts.generate` and `wrapper.ocrd_keraslm_rate` and `lib.Node`.)
@@ -347,8 +351,8 @@ class Rater(object):
         '''
         
         assert self.status > 1
-        assert self.stateful == False # no implicit state transfer
-        assert self.incremental == True # only explicit state transfer
+        assert self.stateful is False # no implicit state transfer
+        assert self.incremental is True # only explicit state transfer
         # todo: allow graph input (by pruning via history clustering or push forward algorithm;
         #                       or by aggregating lattice input)
         assert len(candidates) == len(initial_states)
@@ -358,30 +362,30 @@ class Rater(object):
         # for batch processing, all hypotheses must be passed together:
         for i, initial_state in enumerate(initial_states):
             if not initial_state:
-                initial_states[i] = [numpy.zeros((self.width), dtype=numpy.float) for n in range(0,self.depth*2)] # h+c per layer
-        states_input = [numpy.vstack([initial_state[layer] for initial_state in initial_states]) for layer in range(0,self.depth*2)] # stack layers across batch (h+c per layer)
+                initial_states[i] = [numpy.zeros((self.width), dtype=numpy.float) for n in range(0, self.depth*2)] # h+c per layer
+        states_input = [numpy.vstack([initial_state[layer] for initial_state in initial_states]) for layer in range(0, self.depth*2)] # stack layers across batch (h+c per layer)
         x = numpy.expand_dims(numpy.eye(256, dtype=numpy.bool)[candidates], axis=1) # one-hot vector for all bytes; add time dimension
         output = self.model.predict_on_batch([x] + states_input)
         probs_output = output[0] # actually we need a (hypo) list of (score) vectors
         states_output = list(output[1:]) # from (layers) tuple
         preds = []
         final_states = []
-        for i in range(0,n):
-            preds.append(probs_output[i,:])
+        for i in range(0, n):
+            preds.append(probs_output[i, :])
             final_states.append([layer[i:i+1] for layer in states_output])
         return preds, final_states
     
     def rate_once(self, textstring):
         '''Predict probabilities from model all at once.
-
+        
         Calculate the probabilities of the character sequence in `textstring`
         according to the current model (predicting all at once).
-
+        
         Return a list of probabilities (one per character/codepoint).
         '''
         
         assert self.status > 1
-        assert self.incremental == False # no explicit state transfer
+        assert self.incremental is False # no explicit state transfer
         text = textstring.encode("utf-8") # byte sequence
         size = len(text)
         steps = self.length if self.stateful else 1
@@ -397,7 +401,7 @@ class Rater(object):
                         if self.variable_length:
                             # partial window (needs interim minibatch size 1)
                             sequences.append(text[0:i])
-                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
+                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, sequences)), dtype=numpy.uint8)]
                             yield x
                             sequences = []
                         else:
@@ -405,10 +409,10 @@ class Rater(object):
                             sequences.append(b'\0' * (self.length - i) + text[0:i])
                     else:
                         sequences.append(text[i - self.length: i])
-                    if (len(sequences) % self.minibatch_size == 0 or 
+                    if (len(sequences) % self.minibatch_size == 0 or
                         i + steps >= size-1): # last minibatch: partially filled batch (smaller than self.minibatch_size)
                         # vectorization
-                        x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
+                        x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, sequences)), dtype=numpy.uint8)]
                         yield x
                         sequences = []
                     if i + steps >= size-1: # last minibatch: 1 sample with partial length
@@ -417,20 +421,21 @@ class Rater(object):
                         else:
                             sequences.append(text[size-1 - self.length: size-1])
                         # vectorization
-                        x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
+                        x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, sequences)), dtype=numpy.uint8)]
                         yield x
                 break # cause StopIteration exception (epoch size miscalculation)
-        
-        preds = self.model.predict_generator(gen_data(text), steps=epoch_size, verbose=1) # todo: make iterator thread-safe and use_multiprocesing=True
-        preds = preds.reshape((size-1,256)) # reshape concatenation of batches to a contiguous temporal sequence
+
+        # todo: make iterator thread-safe and then use_multiprocesing=True
+        preds = self.model.predict_generator(gen_data(text), steps=epoch_size, verbose=1)
+        preds = preds.reshape((size-1, 256)) # reshape concatenation of batches to a contiguous temporal sequence
         # get predictions for true symbols (bytes)
-        probs = [1/256]+preds[range(size-1),bytearray(text)[1:]].tolist() # all symbols but first byte (uniform prediction)
+        probs = [1/256]+preds[range(size-1), bytearray(text)[1:]].tolist() # all symbols but first byte (uniform prediction)
         # get predictions for true symbols (characters)
         encoder = codecs.getincrementalencoder("utf-8")()
         cprobs = [1.0] * len(textstring)
         j = 0
-        for (i,c) in enumerate(textstring):
-            for k in range(len(encoder.encode(c))):
+        for i, char in enumerate(textstring):
+            for _ in range(len(encoder.encode(char))):
                 cprobs[i] *= probs[j]
                 j += 1
         assert j == len(text)
@@ -438,15 +443,15 @@ class Rater(object):
     
     def test(self, test_data):
         '''Evaluate model on `test_data` files.
-
-        Calculate the perplexity of the UTF-8 byte sequences in 
+        
+        Calculate the perplexity of the UTF-8 byte sequences in
         all `test_data` files according to the current model.
-
+        
         Return the overall perplexity.
         '''
         
         assert self.status > 1
-        assert self.incremental == False # no explicit state transfer
+        assert self.incremental is False # no explicit state transfer
         self.model.reset_states()
         # todo: Since Keras does not allow callbacks within evaluate() / evaluate_generator() / test_loop(),
         #       we cannot reset_states() between input files as we do in train().
@@ -456,9 +461,9 @@ class Rater(object):
         #       after all?
         epoch_size = 0
         steps = self.length if self.stateful else 1
-        with click.progressbar(test_data) as bar:
-            for f in bar:
-                text = f.read()
+        with click.progressbar(test_data) as pbar:
+            for file in pbar:
+                text = file.read()
                 size = len(text)
                 epoch_size += ceil((size-1)/self.minibatch_size/steps)
         
@@ -466,9 +471,9 @@ class Rater(object):
         def gen_data(files):
             # encode
             while True:
-                for f in files:
-                    f.seek(0)
-                    text = f.read()
+                for file in files:
+                    file.seek(0)
+                    text = file.read()
                     # if self.stateful: reset_cb.reset(f.name)
                     sequences = []
                     next_chars = []
@@ -477,9 +482,9 @@ class Rater(object):
                             if self.variable_length:
                                 # partial window (needs interim minibatch size 1)
                                 sequences.append(text[0:i])
-                                x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
+                                x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, sequences)), dtype=numpy.uint8)]
                                 y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(bytearray(next_chars), dtype=numpy.uint8)]
-                                yield (x,y)
+                                yield (x, y)
                                 sequences = []
                                 next_chars = []
                             else:
@@ -491,15 +496,15 @@ class Rater(object):
                             next_chars.append(text[i+1 - self.length: i+1])
                         else:
                             next_chars.append(text[i])
-                        if (len(sequences) % self.minibatch_size == 0 or 
+                        if (len(sequences) % self.minibatch_size == 0 or
                             i + steps >= len(text)-1): # last minibatch: partially filled batch (smaller than self.minibatch_size)
                             # vectorization
-                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
+                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, sequences)), dtype=numpy.uint8)]
                             if self.stateful:
-                                y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,next_chars)), dtype=numpy.uint8)]
+                                y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, next_chars)), dtype=numpy.uint8)]
                             else:
                                 y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(bytearray(next_chars), dtype=numpy.uint8)]
-                            yield (x,y)
+                            yield (x, y)
                             sequences = []
                             next_chars = []
                         if i + steps >= len(text)-1: # last minibatch: 1 sample with partial length
@@ -510,15 +515,16 @@ class Rater(object):
                                 next_chars.append(text[len(text)])
                                 sequences.append(text[len(text)-1 - self.length: len(text)-1])
                             # vectorization
-                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,sequences)), dtype=numpy.uint8)]
+                            x = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, sequences)), dtype=numpy.uint8)]
                             if self.stateful:
-                                y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray,next_chars)), dtype=numpy.uint8)]
+                                y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(list(map(bytearray, next_chars)), dtype=numpy.uint8)]
                             else:
                                 y = numpy.eye(256, dtype=numpy.bool)[numpy.asarray(bytearray(next_chars), dtype=numpy.uint8)]
-                            yield (x,y)
+                            yield (x, y)
                 break # cause StopIteration exception (epoch size miscalculation)
-        
-        loss, accuracy = self.model.evaluate_generator(gen_data(test_data), steps=epoch_size, verbose=1) # todo: make iterator thread-safe and use_multiprocesing=True
+
+        # todo: make iterator thread-safe and then use_multiprocesing=True
+        loss, _accuracy = self.model.evaluate_generator(gen_data(test_data), steps=epoch_size, verbose=1)
         return exp(loss)
     
 
@@ -530,22 +536,24 @@ class ResetStatesCallback(Callback):
     and between training and validation (on_batch_end with batch>=steps_per_epoch-1).
     '''
     def __init__(self):
+        super(ResetStatesCallback, self).__init__()
         self.eof = False
         self.here = ''
         self.next = ''
     
     def reset(self, where):
+        '''Reset the model after the end of the current batch.'''
         self.eof = True
         self.next = where
     
-    def on_batch_begin(self, batch, logs={}):
+    def on_batch_begin(self, batch, logs=None):
         if self.eof:
             # between training files
             self.model.reset_states()
             self.eof = False
             self.here = self.next
     
-    def on_batch_end(self, batch, logs={}):
+    def on_batch_end(self, batch, logs=None):
         if logs.get('loss') > 25:
             print('huge loss in', self.here, 'at', batch)
         if (self.params['do_validation'] and batch >= self.params['steps']-1):

--- a/ocrd_keraslm/scripts/__init__.py
+++ b/ocrd_keraslm/scripts/__init__.py
@@ -1,0 +1,1 @@
+from .run import cli

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -46,7 +46,8 @@ def apply(model, mapping, text):
     else:
         pass
 
-    ratings = rater.rate(in_string)
+    ratings, perplexity = rater.rate(in_string)
+    click.echo(perplexity)
     click.echo(json.dumps(ratings))
 
 if __name__ == '__main__':

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -54,7 +54,7 @@ def train(model, config, width, depth, length, val_data, data):
     assert rater.status == 2
     if os.path.isfile("model_last.weights.h5"):
         # use best-scoring weights from last checkpoint
-        rename("model_last.weights.h5", model) # mv
+        os.rename("model_last.weights.h5", model) # mv
     else:
         rater.save_weights(model)
 

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -11,44 +11,58 @@ def cli():
 
 @cli.command()
 @click.option('-o', '--output', default="model")
-@click.argument('data')
+@click.argument('data', nargs=-1, type=click.File('r'))
 def train(output, data):
-    """Train a language model"""
-
+    """Train a language model from `data` files"""
+    
     # train
     rater = lib.Rater()
-    with open(str(data),"r") as f:
-        training_data = f.read()
-
-        rater.train(training_data)
-
+    # training_data = u""
+    # for f in data:
+    #     training_data += f.read()
+    # 
+    # rater.train(training_data)
+    rater.train(data)
+    
     # save model and dicts
     rater.save(output)
 
 @cli.command()
 @click.option('-m', '--model', required=True)
 @click.option('-M', '--mapping', required=True)
-@click.argument('TEXT')
+@click.argument('text', type=click.STRING) # todo: create custom click.ParamType for graph/FST input
 def apply(model, mapping, text):
-    """Apply a language model"""
-
+    """Apply a language model to `text` string"""
+    
     # load model
     rater = lib.Rater()
     rater.load(mapping,model)
-
-    # read input
-    in_string = u""
+    
     if text:
         if text[0] == u"-":
             text = sys.stdin
-        for line in text:
-            in_string += line
     else:
         pass
-
-    ratings, perplexity = rater.rate(in_string)
+    
+    ratings, perplexity = rater.rate(text)
     click.echo(perplexity)
     click.echo(json.dumps(ratings))
+
+@cli.command()
+@click.option('-m', '--model', required=True)
+@click.option('-M', '--mapping', required=True)
+@click.argument('data', nargs=-1, type=click.File('r'))
+def test(model, mapping, data):
+    """Apply a language model to `data` files"""
+    
+    # load model
+    rater = lib.Rater()
+    rater.load(mapping,model)
+    
+    # evaluate on files
+    perplexity = rater.test(data)
+    click.echo(perplexity)
+
 
 if __name__ == '__main__':
     cli()

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -119,7 +119,7 @@ def generate(model, config, number, context):
     rater.load_weights(model)
 
     # initial state
-    context_states = [[numpy.zeros((rater.width), dtype=numpy.float) for n in range(0,rater.depth*2)]] # h+c per layer, but only 1 hypothesis
+    context_states = [None]
     # context (to get correct initial state)
     context_bytes = context.encode("utf-8")
     for b in context_bytes[:-1]: # all but last byte

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -11,17 +11,12 @@ def cli():
 
 @cli.command()
 @click.option('-o', '--output', default="model")
-@click.argument('data', nargs=-1, type=click.File('r'))
+@click.argument('data', nargs=-1, type=click.File('rb'))
 def train(output, data):
     """Train a language model from `data` files"""
     
     # train
     rater = lib.Rater()
-    # training_data = u""
-    # for f in data:
-    #     training_data += f.read()
-    # 
-    # rater.train(training_data)
     rater.train(data)
     
     # save model and dicts
@@ -29,35 +24,33 @@ def train(output, data):
 
 @cli.command()
 @click.option('-m', '--model', required=True)
-@click.option('-M', '--mapping', required=True)
 @click.argument('text', type=click.STRING) # todo: create custom click.ParamType for graph/FST input
-def apply(model, mapping, text):
+def apply(model, text):
     """Apply a language model to `text` string"""
     
     # load model
     rater = lib.Rater()
-    rater.load(mapping,model)
+    rater.load(model)
     
     if text:
         if text[0] == u"-":
-            text = sys.stdin
+            text = sys.stdin.read()
     else:
         pass
     
     ratings, perplexity = rater.rate(text)
     click.echo(perplexity)
-    click.echo(json.dumps(ratings))
+    click.echo(json.dumps(ratings, ensure_ascii=False))
 
 @cli.command()
 @click.option('-m', '--model', required=True)
-@click.option('-M', '--mapping', required=True)
-@click.argument('data', nargs=-1, type=click.File('r'))
-def test(model, mapping, data):
+@click.argument('data', nargs=-1, type=click.File('rb'))
+def test(model, data):
     """Apply a language model to `data` files"""
     
     # load model
     rater = lib.Rater()
-    rater.load(mapping,model)
+    rater.load(model)
     
     # evaluate on files
     perplexity = rater.test(data)

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -2,9 +2,12 @@
 from __future__ import absolute_import
 
 import os
-import click, sys, json
-import numpy, codecs
+import sys
+import codecs
 from bisect import insort_left
+import json
+import click
+import numpy
 
 from ocrd_keraslm import lib
 
@@ -41,7 +44,7 @@ def train(model, config, width, depth, length, val_data, data):
     
     rater.configure()
     if incremental:
-        print ('loading weights for incremental training')
+        print('loading weights for incremental training')
         rater.load_weights(model)
     if val_data:
         val_files = [os.path.join(val_data, f) for f in os.listdir(val_data)]
@@ -127,8 +130,8 @@ def generate(model, config, number, context):
     context_states = [None]
     # context (to get correct initial state)
     context_bytes = context.encode("utf-8")
-    for b in context_bytes[:-1]: # all but last byte
-        _, context_states = rater.rate_single([b], context_states)
+    for context_byte in context_bytes[:-1]: # all but last byte
+        _, context_states = rater.rate_single([context_byte], context_states)
     decoder = codecs.getincrementaldecoder('utf-8')()
     decoder.decode(context_bytes)
     next_fringe = [lib.Node(parent=None,
@@ -137,7 +140,7 @@ def generate(model, config, number, context):
                             cost=0.0,
                             extras=decoder.getstate())]
     # beam search
-    for i in range(0,number): # iterate over number of bytes to be generated
+    for _ in range(0, number): # iterate over number of bytes to be generated
         fringe = next_fringe
         preds, states = rater.rate_single([n.value for n in fringe], [n.state for n in fringe])
         next_fringe = []

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 
 from os.path import isfile
 import click, sys, json
+import numpy, codecs
+from bisect import insort_left
 
 from ocrd_keraslm import lib
 
@@ -15,7 +17,7 @@ def cli():
 @click.option('-c', '--config', default="model.config.pkl", help='model config file', type=click.Path(dir_okay=False, writable=True))
 @click.option('-w', '--width', default=128, help='number of nodes per hidden layer', type=click.IntRange(min=1, max=9128))
 @click.option('-d', '--depth', default=2, help='number of hidden layers', type=click.IntRange(min=1, max=10))
-@click.option('-l', '--length', default=5, help='number of previous bytes seen (window size)', type=click.IntRange(min=1, max=500))
+@click.option('-l', '--length', default=256, help='number of previous bytes seen (window size)', type=click.IntRange(min=1, max=500))
 @click.argument('data', nargs=-1, type=click.File('rb'))
 def train(model, config, width, depth, length, data):
     """Train a language model from DATA files,
@@ -100,6 +102,60 @@ def test(model, config, data):
     perplexity = rater.test(data)
     click.echo(perplexity)
 
+@cli.command(short_help='sample characters from language model')
+@click.option('-m', '--model', required=True, help='model weights file', type=click.Path(dir_okay=False, exists=True))
+@click.option('-c', '--config', required=True, help='model config file', type=click.Path(dir_okay=False, exists=True))
+@click.option('-n', '--number', default=1, help='number of bytes to sample', type=click.IntRange(min=1, max=10000))
+@click.argument('context', type=click.STRING)
+def generate(model, config, number, context):
+    """Apply a language model, generating the most probable characters (starting with CONTEXT string)."""
+
+    # load model
+    rater = lib.Rater()
+    rater.load_config(config)
+    rater.stateful = False # no implicit state transfer
+    rater.incremental = True # but explicit state transfer
+    rater.configure()
+    rater.load_weights(model)
+
+    # initial state
+    context_states = [[numpy.zeros((rater.width), dtype=numpy.float) for n in range(0,rater.depth*2)]] # h+c per layer, but only 1 hypothesis
+    # context (to get correct initial state)
+    context_bytes = context.encode("utf-8")
+    for b in context_bytes[:-1]: # all but last byte
+        _, context_states = rater.rate_single([b], context_states)
+    decoder = codecs.getincrementaldecoder('utf-8')()
+    decoder.decode(context_bytes)
+    next_fringe = [lib.Node(parent=None,
+                            state=context_states[0],
+                            value=context_bytes[-1], # last byte
+                            cost=0.0,
+                            extras=decoder.getstate())]
+    # beam search
+    for i in range(0,number): # iterate over number of bytes to be generated
+        fringe = next_fringe
+        preds, states = rater.rate_single([n.value for n in fringe], [n.state for n in fringe])
+        next_fringe = []
+        for j, n in enumerate(fringe): # iterate over batch
+            pred = preds[j]
+            pred_best = numpy.argsort(pred)[-10:] # keep only 10-best alternatives
+            pred_best = pred_best[numpy.searchsorted(pred[pred_best], 0.004):] # keep only alternatives better than 1/256 (uniform distribution)
+            costs = -numpy.log(pred[pred_best])
+            state = states[j]
+            for best, cost in zip(pred_best, costs): # follow up on best predictions
+                decoder.setstate(n.extras)
+                try:
+                    decoder.decode(bytes([best]))
+                    n_new = lib.Node(parent=n, state=state, value=best, cost=cost, extras=decoder.getstate())
+                    insort_left(next_fringe, n_new) # add alternative to tree
+                except UnicodeDecodeError:
+                    pass # ignore this alternative
+        next_fringe = next_fringe[:256] # keep 256-best paths (equals batch size)
+    # todo: keep only candidates with clean decoder state (no partial codepoints), then resort
+    best = next_fringe[0] # best-scoring
+    result = bytes([n.value for n in best.to_sequence()])
+    click.echo(context_bytes[:-1] + result)
+    
 
 if __name__ == '__main__':
     cli()

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -68,6 +68,8 @@ def apply(model, config, text):
     ratings, perplexity = rater.rate(text)
     click.echo(perplexity)
     click.echo(json.dumps(ratings, ensure_ascii=False))
+    #probs = rater.rate_once(text)
+    #click.echo(json.dumps(probs))
 
 @cli.command(short_help='get overall perplexity from language model')
 @click.option('-m', '--model', required=True, help='model weights file', type=click.Path(dir_okay=False, exists=True))

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+from os.path import isfile
 import click, sys, json
 
 from ocrd_keraslm import lib
@@ -25,6 +26,11 @@ def train(model, config, width, depth, length, data):
     
     # train
     rater = lib.Rater()
+    incremental = False
+    if isfile(model) and isfile(config):
+        rater.load_config(config)
+        if rater.width == width and rater.depth == depth:
+            incremental = True
     rater.width = width
     rater.depth = depth
     rater.length = length
@@ -32,6 +38,9 @@ def train(model, config, width, depth, length, data):
         rater.minibatch_size = rater.length # make sure states are consistent with windows after 1 minibatch
     
     rater.configure()
+    if incremental:
+        print ('loading weights for incremental training')
+        rater.load_weights(model)
     rater.train(data)
     
     # save model and dicts

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -9,41 +9,55 @@ from ocrd_keraslm import lib
 def cli():
     pass
 
-@cli.command()
-@click.option('-m', '--model', default="model.weights.h5", type=click.Path(dir_okay=False, writable=True))
-@click.option('-c', '--config', default="model.config.pkl", type=click.Path(dir_okay=False, writable=True))
-@click.option('-w', '--width', default=128, type=click.IntRange(min=1, max=9128))
-@click.option('-d', '--depth', default=2, type=click.IntRange(min=1, max=10))
-@click.option('-l', '--length', default=5, type=click.IntRange(min=1, max=500))
+@cli.command(short_help='train a language model')
+@click.option('-m', '--model', default="model.weights.h5", help='model weights file', type=click.Path(dir_okay=False, writable=True))
+@click.option('-c', '--config', default="model.config.pkl", help='model config file', type=click.Path(dir_okay=False, writable=True))
+@click.option('-w', '--width', default=128, help='number of nodes per hidden layer', type=click.IntRange(min=1, max=9128))
+@click.option('-d', '--depth', default=2, help='number of hidden layers', type=click.IntRange(min=1, max=10))
+@click.option('-l', '--length', default=5, help='number of previous bytes seen (window size)', type=click.IntRange(min=1, max=500))
 @click.argument('data', nargs=-1, type=click.File('rb'))
 def train(model, config, width, depth, length, data):
-    """Train a language model from `data` files,
-       with `width` nodes per hidden layer,
-       with `depth` hidden layers,
-       with `length` bytes window size.
+    """Train a language model from DATA files,
+       with parameters WIDTH, DEPTH, and LENGTH.
+
+       The files will be randomly split into training and validation data.
     """
     
     # train
     rater = lib.Rater()
-    rater.train(data, width, depth, length)
+    rater.width = width
+    rater.depth = depth
+    rater.length = length
+    if rater.stateful: # override necessary before compilation: 
+        rater.minibatch_size = rater.length # make sure states are consistent with windows after 1 minibatch
+    
+    rater.configure()
+    rater.train(data)
     
     # save model and dicts
     #rater.save(model)
-    rater.save2(config, model)
+    rater.save_config(config)
+    rater.save_weights(model)
 
-@cli.command()
-@click.option('-m', '--model', required=True, type=click.Path(dir_okay=False, exists=True))
-@click.option('-c', '--config', required=True, type=click.Path(dir_okay=False, exists=True))
+@cli.command(short_help='get individual probabilities from language model')
+@click.option('-m', '--model', required=True, help='model weights file', type=click.Path(dir_okay=False, exists=True))
+@click.option('-c', '--config', required=True, help='model config file', type=click.Path(dir_okay=False, exists=True))
 @click.argument('text', type=click.STRING) # todo: create custom click.ParamType for graph/FST input
 def apply(model, config, text):
-    """Apply a language model to `text` string"""
+    """Apply a language model to TEXT string and compute its individual probabilities.
+
+       If TEXT is the symbol '-', the string will be read from standard input.
+    """
     
     # load model
     rater = lib.Rater()
-    if rater.stateful:
-        rater.minibatch_size = 1 # override necessary before compilation
     #rater.load(model)
-    rater.load2(config, model)
+    rater.load_config(config)
+    if rater.stateful: # override necessary before compilation: 
+        rater.length = 1 # allow single-sample batches
+        rater.minibatch_size = rater.length # make sure states are consistent with windows after 1 minibatch
+    rater.configure()
+    rater.load_weights(model)
     
     if text:
         if text[0] == u"-":
@@ -55,17 +69,21 @@ def apply(model, config, text):
     click.echo(perplexity)
     click.echo(json.dumps(ratings, ensure_ascii=False))
 
-@cli.command()
-@click.option('-m', '--model', required=True, type=click.Path(dir_okay=False, exists=True))
-@click.option('-c', '--config', required=True, type=click.Path(dir_okay=False, exists=True))
+@cli.command(short_help='get overall perplexity from language model')
+@click.option('-m', '--model', required=True, help='model weights file', type=click.Path(dir_okay=False, exists=True))
+@click.option('-c', '--config', required=True, help='model config file', type=click.Path(dir_okay=False, exists=True))
 @click.argument('data', nargs=-1, type=click.File('rb'))
 def test(model, config, data):
-    """Apply a language model to `data` files"""
+    """Apply a language model to DATA files and compute its overall perplexity."""
     
     # load model
     rater = lib.Rater()
     #rater.load(model)
-    rater.load2(config, model)
+    rater.load_config(config)
+    if rater.stateful: # override necessary before compilation: 
+        rater.minibatch_size = rater.length # make sure states are consistent with windows after 1 minibatch
+    rater.configure()
+    rater.load_weights(model)
     
     # evaluate on files
     perplexity = rater.test(data)

--- a/ocrd_keraslm/scripts/run.py
+++ b/ocrd_keraslm/scripts/run.py
@@ -10,20 +10,27 @@ def cli():
     pass
 
 @cli.command()
-@click.option('-o', '--output', default="model")
+@click.option('-m', '--model', default="model.h5", type=click.Path(dir_okay=False, writable=True))
+@click.option('-w', '--width', default=128, type=click.IntRange(min=1, max=9128))
+@click.option('-d', '--depth', default=2, type=click.IntRange(min=1, max=10))
+@click.option('-l', '--length', default=5, type=click.IntRange(min=1, max=500))
 @click.argument('data', nargs=-1, type=click.File('rb'))
-def train(output, data):
-    """Train a language model from `data` files"""
+def train(model, width, depth, length, data):
+    """Train a language model from `data` files,
+       with `width` nodes per hidden layer,
+       with `depth` hidden layers,
+       with `length` bytes window size.
+    """
     
     # train
     rater = lib.Rater()
-    rater.train(data)
+    rater.train(data, width, depth, length)
     
     # save model and dicts
-    rater.save(output)
+    rater.save(model)
 
 @cli.command()
-@click.option('-m', '--model', required=True)
+@click.option('-m', '--model', required=True, type=click.Path(dir_okay=False, exists=True))
 @click.argument('text', type=click.STRING) # todo: create custom click.ParamType for graph/FST input
 def apply(model, text):
     """Apply a language model to `text` string"""
@@ -43,7 +50,7 @@ def apply(model, text):
     click.echo(json.dumps(ratings, ensure_ascii=False))
 
 @cli.command()
-@click.option('-m', '--model', required=True)
+@click.option('-m', '--model', required=True, type=click.Path(dir_okay=False, exists=True))
 @click.argument('data', nargs=-1, type=click.File('rb'))
 def test(model, data):
     """Apply a language model to `data` files"""

--- a/ocrd_keraslm/wrapper/ocrd-tool.json
+++ b/ocrd_keraslm/wrapper/ocrd-tool.json
@@ -1,6 +1,6 @@
 {
   "git_url": "https://github.com/OCR-D/ocrd_keraslm",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "tools": {
     "ocrd-keraslm-rate": {
       "executable": "ocrd-keraslm-rate",
@@ -10,15 +10,28 @@
       "steps": [
         "recognition/text-recognition"
       ],
-      "description": "Rate text with keras",
+      "description": "Rate each element of the text with a byte-level LSTM language model in Keras",
       "parameters": {
-        "model": {
+        "weight_file": {
           "type": "string",
+          "description": "path of h5 weight file for model trained with keraslm",
           "required": true
         },
-        "mapping": {
+        "config_file": {
           "type": "string",
+          "description": "path of pkl config file for model trained with keraslm",
           "required": true
+        },
+        "textequiv_level": {
+          "type": "string",
+          "enum": ["region", "line", "word", "glyph"],
+          "default": "glyph",
+          "description": "PAGE XML hierarchy level to evaluate TextEquiv sequences on"
+        },
+        "add_space_glyphs": {
+          "type": "boolean",
+          "description": "whether to insert whitespace and newline as pseudo-glyphs in result (at glyph level)",
+          "default": false
         }
       }
     }

--- a/ocrd_keraslm/wrapper/ocrd-tool.json
+++ b/ocrd_keraslm/wrapper/ocrd-tool.json
@@ -1,6 +1,6 @@
 {
   "git_url": "https://github.com/OCR-D/ocrd_keraslm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "tools": {
     "ocrd-keraslm-rate": {
       "executable": "ocrd-keraslm-rate",
@@ -32,6 +32,11 @@
           "type": "boolean",
           "description": "whether to insert whitespace and newline as pseudo-glyphs in result (at glyph level)",
           "default": false
+        },
+        "alternative_decoding": {
+          "type": "boolean",
+          "description": "whether to process all TextEquiv alternatives, finding the best path via beam search, and delete each non-best alternative",
+          "default": true
         }
       }
     }

--- a/ocrd_keraslm/wrapper/ocrd-tool.json
+++ b/ocrd_keraslm/wrapper/ocrd-tool.json
@@ -37,6 +37,12 @@
           "type": "boolean",
           "description": "whether to process all TextEquiv alternatives, finding the best path via beam search, and delete each non-best alternative",
           "default": true
+        },
+        "beam_width": {
+          "type": "number",
+          "format": "integer",
+          "description": "maximum number of best partial paths to consider during search with alternative_decoding",
+          "default": 100
         }
       }
     }

--- a/ocrd_keraslm/wrapper/rate.py
+++ b/ocrd_keraslm/wrapper/rate.py
@@ -5,17 +5,17 @@ from numpy.linalg import norm
 
 from ocrd import Processor, MIMETYPE_PAGE
 from ocrd.utils import getLogger, concat_padded, xywh_from_points, points_from_xywh
-from ocrd_keraslm.wrapper.config import OCRD_TOOL
 from ocrd.model.ocrd_page import from_file, to_xml, GlyphType, CoordsType, TextEquivType
 from ocrd.model.ocrd_page_generateds import MetadataItemType, LabelsType, LabelType
 
+from ocrd_keraslm.wrapper.config import OCRD_TOOL
 from ocrd_keraslm import lib
 
 logger = getLogger('processor.KerasRate')
 
 CHOICE_THRESHOLD_NUM = 4 # maximum number of choices to try per element
 CHOICE_THRESHOLD_CONF = 0.1 # maximum score drop from best choice to try per element
-#BEAM_WIDTH = 100 # maximum number of best partial paths to consider during search with alternative_decoding
+#beam_width = 100 # maximum number of best partial paths to consider during search with alternative_decoding
 BEAM_CLUSTERING_ENABLE = True # enable pruning partial paths by history clustering
 BEAM_CLUSTERING_DIST = 5 # maximum distance between state vectors to form a cluster
 MAX_ELEMENTS = 500 # maximum number of lower level elements embedded within each element (for word/glyph iterators)
@@ -31,7 +31,7 @@ class KerasRate(Processor):
         
         self.rater = lib.Rater()
         self.rater.load_config(self.parameter['config_file'])
-        if self.rater.stateful: # override necessary before compilation: 
+        if self.rater.stateful: # override necessary before compilation:
             self.rater.length = 1 # allow single-sample batches
             self.rater.minibatch_size = self.rater.length # make sure states are consistent with windows after 1 minibatch
         if self.parameter['alternative_decoding']:
@@ -46,7 +46,7 @@ class KerasRate(Processor):
         Performs the rating.
         """
         level = self.parameter['textequiv_level']
-        BEAM_WIDTH = self.parameter['beam_width']
+        beam_width = self.parameter['beam_width']
         for (n, input_file) in enumerate(self.input_files):
             logger.info("INPUT FILE %i / %s", n, input_file)
             pcgts = from_file(self.workspace.download_file(input_file))
@@ -67,7 +67,7 @@ class KerasRate(Processor):
             #        we can only reproduce segmentation if Word boundaries exactly coincide with white space!
             regions = pcgts.get_Page().get_TextRegion()
             if not regions:
-                logger.warn("Page contains no text regions")
+                logger.warning("Page contains no text regions")
             first_region = True
             for region in regions:
                 if level == 'region':
@@ -79,11 +79,11 @@ class KerasRate(Processor):
                     if textequivs:
                         text.append((region, filter_choices(textequivs)))
                     else:
-                        logger.warn("Region '%s' contains no text results", region.id)
+                        logger.warning("Region '%s' contains no text results", region.id)
                     continue
                 lines = region.get_TextLine()
                 if not lines:
-                    logger.warn("Region '%s' contains no text lines", region.id)
+                    logger.warning("Region '%s' contains no text lines", region.id)
                 first_line = True
                 for line in lines:
                     if level == 'line':
@@ -95,11 +95,11 @@ class KerasRate(Processor):
                         if textequivs:
                             text.append((line, filter_choices(textequivs)))
                         else:
-                            logger.warn("Line '%s' contains no text results", line.id)
+                            logger.warning("Line '%s' contains no text results", line.id)
                         continue
                     words = line.get_Word()
                     if not words:
-                        logger.warn("Line '%s' contains no words", line.id)
+                        logger.warning("Line '%s' contains no words", line.id)
                     first_word = True
                     for word in words:
                         if level == 'word':
@@ -113,7 +113,7 @@ class KerasRate(Processor):
                             if textequivs:
                                 text.append((word, filter_choices(textequivs)))
                             else:
-                                logger.warn("Word '%s' contains no text results", word.id)
+                                logger.warning("Word '%s' contains no text results", word.id)
                             continue
                         space_char = None
                         if not first_word:
@@ -126,22 +126,22 @@ class KerasRate(Processor):
                                 xywh = xywh_from_points(word.get_Coords().points)
                                 xywh['w'] = 0
                                 xywh['h'] = 0
-                                space_glyph = GlyphType(id='%s_space' % word.id, 
-                                                        TextEquiv=[space_textequiv], 
+                                space_glyph = GlyphType(id='%s_space' % word.id,
+                                                        TextEquiv=[space_textequiv],
                                                         Coords=CoordsType(points_from_xywh(xywh))) # empty box
                                 word.insert_Glyph_at(0, space_glyph) # add a pseudo glyph in annotation
                             else:
                                 text.append((None, [space_textequiv])) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
                         glyphs = word.get_Glyph()
                         if not glyphs:
-                            logger.warn("Word '%s' contains no glyphs", word.id)
+                            logger.warning("Word '%s' contains no glyphs", word.id)
                         for glyph in glyphs:
                             logger.debug("Getting text in glyph '%s'", glyph.id)
                             textequivs = glyph.get_TextEquiv()
                             if textequivs:
                                 text.append((glyph, filter_choices(textequivs)))
                             else:
-                                logger.warn("Glyph '%s' contains no text results", glyph.id)
+                                logger.warning("Glyph '%s' contains no text results", glyph.id)
                         first_word = False
                     first_line = False
                 first_region = False
@@ -154,10 +154,10 @@ class KerasRate(Processor):
                     fringe = next_fringe
                     next_fringe = []
                     for node in fringe:
-                        new_nodes = [lib.Node(parent=node, state=node.state, value=node.value, cost=0.0, extras=(element[0],textequiv)) for textequiv in element[1]] # copies of node (keeping value+state until prediction)
+                        new_nodes = [lib.Node(parent=node, state=node.state, value=node.value, cost=0.0, extras=(element[0], textequiv)) for textequiv in element[1]] # copies of node (keeping value+state until prediction)
                         alternatives = [textequiv.Unicode.encode("utf-8") for textequiv in element[1]] # byte sequences
                         for i in range(MAX_ELEMENTS): # accumulate states and costs of all alternatives (of different length) in node
-                            updates = [j for j in range(len(element[1])) if i<len(alternatives[j])] # indices to update
+                            updates = [j for j in range(len(element[1])) if i < len(alternatives[j])] # indices to update
                             if updates == []:
                                 break
                             preds, states = self.rater.rate_single([new_nodes[u].value for u in updates], [new_nodes[u].state for u in updates])
@@ -166,7 +166,7 @@ class KerasRate(Processor):
                                 new_node.state = states[j]
                                 new_node.cum_cost += -log(max(preds[j][new_node.value], 1e-99), 2)
                         for new_node in new_nodes:
-                            def history_clustering():
+                            def history_clustering(next_fringe):
                                 for old_node in next_fringe:
                                     if (new_node.value == old_node.value and
                                         all(norm(new_node.state[layer]-old_node.state[layer]) < BEAM_CLUSTERING_DIST for layer in range(self.rater.depth))):
@@ -182,13 +182,13 @@ class KerasRate(Processor):
                                             next_fringe.remove(old_node)
                                             break # immediately proceed to insert new_node
                                 return False # proceed to insert new_node (no clustering possible)
-                            if BEAM_CLUSTERING_ENABLE and history_clustering():
+                            if BEAM_CLUSTERING_ENABLE and history_clustering(next_fringe):
                                 continue
                             insort_left(next_fringe, new_node) # insert sorted by cumulative costs
                             # todo: incorporate input confidences, too (weighted product or as input into LM)
                     # todo: history clustering for pruning paths by joining similar nodes (instead of neglecting costly nodes)
-                    #logger.debug("Shrinking %d paths to best %d", len(next_fringe), BEAM_WIDTH)
-                    next_fringe = next_fringe[:BEAM_WIDTH] # keep best paths (equals batch size)
+                    #logger.debug("Shrinking %d paths to best %d", len(next_fringe), beam_width)
+                    next_fringe = next_fringe[:beam_width] # keep best paths (equals batch size)
                 best = next_fringe[0] # best-scoring path
                 best_len = 0
                 for node in best.to_sequence()[1:]: # ignore root node
@@ -224,7 +224,7 @@ class KerasRate(Processor):
                 if i != len(confidences):
                     logger.err("Input text length and output scores length are off by %d characters", i-len(confidences))
                 avg = sum(confidences)/len(confidences)
-                ent = sum([-log(max(p,1e-99), 2) for p in confidences])/len(confidences)
+                ent = sum([-log(max(p, 1e-99), 2) for p in confidences])/len(confidences)
                 ppl = pow(2.0, ent) # character level
                 ppll = pow(2.0, ent * len(confidences)/len(text)) # textequiv level (including spaces/newlines)
                 logger.info("avg: %.3f, char ppl: %.3f, %s ppl: %.3f", avg, ppl, level, ppll) # char need not always equal glyph!
@@ -239,11 +239,11 @@ class KerasRate(Processor):
 
 def filter_choices(textequivs):
     '''assuming `textequivs` are already sorted by input confidence (conf attribute), ensure maximum number and maximum relative threshold'''
-    textequivs = textequivs[:min(CHOICE_THRESHOLD_NUM,len(textequivs))]
-    if len(textequivs) > 0:
+    textequivs = textequivs[:min(CHOICE_THRESHOLD_NUM, len(textequivs))]
+    if textequivs:
         conf0 = textequivs[0].conf
         if conf0:
-            return [te for te in textequivs if (conf0 - te.conf < CHOICE_THRESHOLD_CONF)]
+            return [te for te in textequivs if conf0 - te.conf < CHOICE_THRESHOLD_CONF]
         else:
             return textequivs
     else:

--- a/ocrd_keraslm/wrapper/rate.py
+++ b/ocrd_keraslm/wrapper/rate.py
@@ -15,7 +15,7 @@ logger = getLogger('processor.KerasRate')
 
 CHOICE_THRESHOLD_NUM = 4 # maximum number of choices to try per element
 CHOICE_THRESHOLD_CONF = 0.1 # maximum score drop from best choice to try per element
-BEAM_WIDTH = 100 # maximum number of best partial paths to consider during search with alternative_decoding
+#BEAM_WIDTH = 100 # maximum number of best partial paths to consider during search with alternative_decoding
 BEAM_CLUSTERING_ENABLE = True # enable pruning partial paths by history clustering
 BEAM_CLUSTERING_DIST = 5 # maximum distance between state vectors to form a cluster
 MAX_ELEMENTS = 500 # maximum number of lower level elements embedded within each element (for word/glyph iterators)
@@ -46,6 +46,7 @@ class KerasRate(Processor):
         Performs the rating.
         """
         level = self.parameter['textequiv_level']
+        BEAM_WIDTH = self.parameter['beam_width']
         for (n, input_file) in enumerate(self.input_files):
             logger.info("INPUT FILE %i / %s", n, input_file)
             pcgts = from_file(self.workspace.download_file(input_file))

--- a/ocrd_keraslm/wrapper/rate.py
+++ b/ocrd_keraslm/wrapper/rate.py
@@ -1,40 +1,154 @@
 from __future__ import absolute_import
+from math import log
 
 from ocrd import Processor, MIMETYPE_PAGE
-from ocrd.utils import getLogger, concat_padded
+from ocrd.utils import getLogger, concat_padded, xywh_from_points, points_from_xywh
 from ocrd_keraslm.wrapper.config import OCRD_TOOL
-from ocrd.model.ocrd_page import from_file, to_xml
+from ocrd.model.ocrd_page import from_file, to_xml, GlyphType, CoordsType, TextEquivType
+from ocrd.model.ocrd_page_generateds import MetadataItemType, LabelsType, LabelType
 
 from ocrd_keraslm import lib
 
-log = getLogger('processor.KerasRate')
+logger = getLogger('processor.KerasRate')
 
 class KerasRate(Processor):
-
+    
     def __init__(self, *args, **kwargs):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools']['ocrd-keraslm-rate']
         kwargs['version'] = OCRD_TOOL['version']
         super(KerasRate, self).__init__(*args, **kwargs)
+        if not hasattr(self, 'workspace') or not self.workspace: # no parameter/workspace for --dump-json or --version (no processing)
+            return
+        
         self.rater = lib.Rater()
-        self.rater.load(self.parameter['mapping'],self.parameter['model'])
-
+        self.rater.load_config(self.parameter['config_file'])
+        if self.rater.stateful: # override necessary before compilation: 
+            self.rater.length = 1 # allow single-sample batches
+            self.rater.minibatch_size = self.rater.length # make sure states are consistent with windows after 1 minibatch
+        self.rater.configure()
+        self.rater.load_weights(self.parameter['weight_file'])
+    
     def process(self):
         """
         Performs the rating.
         """
+        level = self.parameter['textequiv_level']
         for (n, input_file) in enumerate(self.input_files):
-            log.info("INPUT FILE %i / %s", n, input_file)
+            logger.info("INPUT FILE %i / %s", n, input_file)
             pcgts = from_file(self.workspace.download_file(input_file))
-            for region in pcgts.get_Page().get_TextRegion():
-                for line in region.get_TextLine():
-                    for word in line.get_Word():
-                        context = u""
-                        for glyph in word.get_Glyph():
-                            if glyph.get_TextEquiv():
-                                context += glyph.get_TextEquiv()[0].Unicode
-                                glyph.set_custom("%.8f" % self.rater.rate_single(context))
+            logger.info("Scoring text in page '%s' at the %s level", pcgts.get_pcGtsId(), level)
+            metadata = pcgts.get_Metadata() # ensured by from_file()
+            metadata.add_MetadataItem(
+                MetadataItemType(type_="processingStep",
+                                 name=OCRD_TOOL['tools']['ocrd-keraslm-rate']['steps'][0],
+                                 value='ocrd-keraslm-rate',
+                                 Labels=[LabelsType(externalRef="parameters",
+                                                    Label=[LabelType(type_=name,
+                                                                     value=self.parameter[name])
+                                                           for name in self.parameter.keys()])]))
+            text = []
+            # white space at word boundaries, newline at line/region boundaries: required for LM input
+            # FIXME: tokenization ambiguity (i.e. segmenting punctuation into Word suffixes or extra elements)
+            #        is handled very differently between GT and ocrd_tesserocr annotation...
+            #        we can only reproduce segmentation if Word boundaries exactly coincide with white space!
+            regions = pcgts.get_Page().get_TextRegion()
+            if not regions:
+                logger.warn("Page contains no text regions")
+            first_region = True
+            for region in regions:
+                if level == 'region':
+                    logger.debug("Getting text in region '%s'", region.id)
+                    if not first_region:
+                        text.append(TextEquivType(Unicode=u'\n')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                    first_region = False
+                    textequivs = region.get_TextEquiv()
+                    if textequivs:
+                        text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                    else:
+                        logger.warn("Region '%s' contains no text results", region.id)
+                    continue
+                lines = region.get_TextLine()
+                if not lines:
+                    logger.warn("Region '%s' contains no text lines", region.id)
+                first_line = True
+                for line in lines:
+                    if level == 'line':
+                        logger.debug("Getting text in line '%s'", line.id)
+                        if not first_line or not first_region:
+                            text.append(TextEquivType(Unicode=u'\n')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                        first_line = False
+                        textequivs = line.get_TextEquiv()
+                        if textequivs:
+                            text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                        else:
+                            logger.warn("Line '%s' contains no text results", line.id)
+                        continue
+                    words = line.get_Word()
+                    if not words:
+                        logger.warn("Line '%s' contains no words", line.id)
+                    first_word = True
+                    for word in words:
+                        if level == 'word':
+                            logger.debug("Getting text in word '%s'", word.id)
+                            if not first_word:
+                                text.append(TextEquivType(Unicode=u' ')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                            elif not first_line or not first_region:
+                                text.append(TextEquivType(Unicode=u'\n')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                            first_word = False
+                            textequivs = word.get_TextEquiv()
+                            if textequivs:
+                                text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                            else:
+                                logger.warn("Word '%s' contains no text results", word.id)
+                            continue
+                        space_char = None
+                        if not first_word:
+                            space_char = u' '
+                        elif not first_line or not first_region:
+                            space_char = u'\n'
+                        if space_char: # space required for LM input
+                            space_textequiv = TextEquivType(Unicode=space_char)
+                            if self.parameter['add_space_glyphs']:
+                                xywh = xywh_from_points(word.get_Coords().points)
+                                xywh['w'] = 0
+                                xywh['h'] = 0
+                                space_glyph = GlyphType(id='%s_space' % word.id, 
+                                                        TextEquiv=[space_textequiv], 
+                                                        Coords=CoordsType(points_from_xywh(xywh))) # empty box
+                                word.insert_Glyph_at(0, space_glyph) # add a pseudo glyph in annotation
+                            else:
+                                text.append(space_textequiv) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                        glyphs = word.get_Glyph()
+                        if not glyphs:
+                            logger.warn("Word '%s' contains no glyphs", word.id)
+                        for glyph in glyphs:
+                            logger.debug("Getting text in glyph '%s'", glyph.id)
+                            textequivs = glyph.get_TextEquiv()
+                            if textequivs:
+                                text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                            else:
+                                logger.warn("Glyph '%s' contains no text results", glyph.id)
+                        first_word = False
+                    first_line = False
+                first_region = False
+            textstring = u''.join(te.Unicode for te in text) # same length as text
+            logger.debug("Rating %d characters", len(textstring))
+            confidences = self.rater.rate_once(textstring)
+            avg = sum(confidences)/len(confidences)
+            ent = sum([-log(p, 2) for p in confidences])/len(confidences)
+            ppl = pow(2.0, ent) # character level
+            ppll = pow(2.0, ent * len(confidences)/len(text)) # textequiv level
+            logger.debug("avg: %.3f, char ppl: %.3f, %s ppl: %.3f", avg, ppl, level, ppll) # char need not always equal glyph!
+            i = 0
+            for textequiv in text:
+                j = len(textequiv.Unicode)
+                conf = sum(confidences[i:i+j])/j
+                textequiv.set_conf(conf) # or multiply to existing value?
+                i += j
+            if i != len(confidences):
+                logger.err("Input text length and output scores length are off by %d characters", i-len(confidences))
             ID = concat_padded(self.output_file_grp, n)
-            self.add_output_file(
+            self.workspace.add_file(
                 ID=ID,
                 file_grp=self.output_file_grp,
                 basename=ID + '.xml',

--- a/ocrd_keraslm/wrapper/rate.py
+++ b/ocrd_keraslm/wrapper/rate.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from math import log
 from bisect import insort_left
+from numpy.linalg import norm
 
 from ocrd import Processor, MIMETYPE_PAGE
 from ocrd.utils import getLogger, concat_padded, xywh_from_points, points_from_xywh
@@ -12,9 +13,11 @@ from ocrd_keraslm import lib
 
 logger = getLogger('processor.KerasRate')
 
-CHOICE_THRESHOLD_NUM = 3 # maximum number of choices to try per element
-CHOICE_THRESHOLD_CONF = 0.2 # maximum score drop from best choice to try per element
-BEAM_WIDTH = 100 # maximum number of paths to consider during search
+CHOICE_THRESHOLD_NUM = 4 # maximum number of choices to try per element
+CHOICE_THRESHOLD_CONF = 0.1 # maximum score drop from best choice to try per element
+BEAM_WIDTH = 100 # maximum number of best partial paths to consider during search with alternative_decoding
+BEAM_CLUSTERING_ENABLE = True # enable pruning partial paths by history clustering
+BEAM_CLUSTERING_DIST = 5 # maximum distance between state vectors to form a cluster
 MAX_ELEMENTS = 500 # maximum number of lower level elements embedded within each element (for word/glyph iterators)
 
 class KerasRate(Processor):
@@ -150,7 +153,7 @@ class KerasRate(Processor):
                     fringe = next_fringe
                     next_fringe = []
                     for node in fringe:
-                        new_nodes = [lib.Node(parent=node, state=node.state, value=node.value, cost=0.0, extras=(element[0],textequiv.index)) for textequiv in element[1]] # copies of node (keeping value+state until prediction)
+                        new_nodes = [lib.Node(parent=node, state=node.state, value=node.value, cost=0.0, extras=(element[0],textequiv)) for textequiv in element[1]] # copies of node (keeping value+state until prediction)
                         alternatives = [textequiv.Unicode.encode("utf-8") for textequiv in element[1]] # byte sequences
                         for i in range(MAX_ELEMENTS): # accumulate states and costs of all alternatives (of different length) in node
                             updates = [j for j in range(len(element[1])) if i<len(alternatives[j])] # indices to update
@@ -162,6 +165,24 @@ class KerasRate(Processor):
                                 new_node.state = states[j]
                                 new_node.cum_cost += -log(max(preds[j][new_node.value], 1e-99), 2)
                         for new_node in new_nodes:
+                            def history_clustering():
+                                for old_node in next_fringe:
+                                    if (new_node.value == old_node.value and
+                                        all(norm(new_node.state[layer]-old_node.state[layer]) < BEAM_CLUSTERING_DIST for layer in range(self.rater.depth))):
+                                        if old_node.cum_cost < new_node.cum_cost:
+                                            # logger.debug("discarding %s in favour of %s due to history clustering",
+                                            #              ''.join([prev_node.extras[1].Unicode for prev_node in new_node.to_sequence()[1:]]),
+                                            #              ''.join([prev_node.extras[1].Unicode for prev_node in old_node.to_sequence()[1:]]))
+                                            return True # continue with next new_node
+                                        else:
+                                            # logger.debug("neglecting %s in favour of %s due to history clustering",
+                                            #              ''.join([prev_node.extras[1].Unicode for prev_node in old_node.to_sequence()[1:]]),
+                                            #              ''.join([prev_node.extras[1].Unicode for prev_node in new_node.to_sequence()[1:]]))
+                                            next_fringe.remove(old_node)
+                                            break # immediately proceed to insert new_node
+                                return False # proceed to insert new_node (no clustering possible)
+                            if BEAM_CLUSTERING_ENABLE and history_clustering():
+                                continue
                             insort_left(next_fringe, new_node) # insert sorted by cumulative costs
                             # todo: incorporate input confidences, too (weighted product or as input into LM)
                     # todo: history clustering for pruning paths by joining similar nodes (instead of neglecting costly nodes)
@@ -169,21 +190,16 @@ class KerasRate(Processor):
                     next_fringe = next_fringe[:BEAM_WIDTH] # keep best paths (equals batch size)
                 best = next_fringe[0] # best-scoring path
                 best_len = 0
-                for node in best.to_sequence():
-                    if not node.parent:
-                        continue # ignore root node
+                for node in best.to_sequence()[1:]: # ignore root node
                     element = node.extras[0]
                     if element: # not just space
                         textequivs = element.get_TextEquiv()
-                        try:
-                            textequiv = next(te for te in textequivs if te.index == node.extras[1])
-                            element.set_TextEquiv([textequiv]) # delete others
-                            textequiv_len = len(textequiv.Unicode.encode("utf-8"))
-                            best_len += textequiv_len
-                            textequiv.set_conf(pow(2.0, -(node.cum_cost-node.parent.cum_cost)/textequiv_len)) # average probability
-                            #print(textequiv.Unicode, end='')
-                        except StopIteration:
-                            logger.err("TextEquiv index %d not found at element '%s'", node.extras[1], element.id)
+                        textequiv = node.extras[1]
+                        element.set_TextEquiv([textequiv]) # delete others
+                        textequiv_len = len(textequiv.Unicode.encode("utf-8"))
+                        best_len += textequiv_len
+                        textequiv.set_conf(pow(2.0, -(node.cum_cost-node.parent.cum_cost)/textequiv_len)) # average probability
+                        #print(textequiv.Unicode, end='')
                     else:
                         best_len += 1
                         #print(bytes([node.value]).decode("utf-8"), end='')

--- a/ocrd_keraslm/wrapper/rate.py
+++ b/ocrd_keraslm/wrapper/rate.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from math import log
+from bisect import insort_left
 
 from ocrd import Processor, MIMETYPE_PAGE
 from ocrd.utils import getLogger, concat_padded, xywh_from_points, points_from_xywh
@@ -10,6 +11,11 @@ from ocrd.model.ocrd_page_generateds import MetadataItemType, LabelsType, LabelT
 from ocrd_keraslm import lib
 
 logger = getLogger('processor.KerasRate')
+
+CHOICE_THRESHOLD_NUM = 3 # maximum number of choices to try per element
+CHOICE_THRESHOLD_CONF = 0.2 # maximum score drop from best choice to try per element
+BEAM_WIDTH = 100 # maximum number of paths to consider during search
+MAX_ELEMENTS = 500 # maximum number of lower level elements embedded within each element (for word/glyph iterators)
 
 class KerasRate(Processor):
     
@@ -25,6 +31,10 @@ class KerasRate(Processor):
         if self.rater.stateful: # override necessary before compilation: 
             self.rater.length = 1 # allow single-sample batches
             self.rater.minibatch_size = self.rater.length # make sure states are consistent with windows after 1 minibatch
+        if self.parameter['alternative_decoding']:
+            # override:
+            self.rater.stateful = False # no implicit state transfer
+            self.rater.incremental = True # but explicit state transfer
         self.rater.configure()
         self.rater.load_weights(self.parameter['weight_file'])
     
@@ -59,11 +69,11 @@ class KerasRate(Processor):
                 if level == 'region':
                     logger.debug("Getting text in region '%s'", region.id)
                     if not first_region:
-                        text.append(TextEquivType(Unicode=u'\n')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                        text.append((None, [TextEquivType(Unicode=u'\n')])) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
                     first_region = False
                     textequivs = region.get_TextEquiv()
                     if textequivs:
-                        text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                        text.append((region, filter_choices(textequivs)))
                     else:
                         logger.warn("Region '%s' contains no text results", region.id)
                     continue
@@ -75,11 +85,11 @@ class KerasRate(Processor):
                     if level == 'line':
                         logger.debug("Getting text in line '%s'", line.id)
                         if not first_line or not first_region:
-                            text.append(TextEquivType(Unicode=u'\n')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                            text.append((None, [TextEquivType(Unicode=u'\n')])) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
                         first_line = False
                         textequivs = line.get_TextEquiv()
                         if textequivs:
-                            text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                            text.append((line, filter_choices(textequivs)))
                         else:
                             logger.warn("Line '%s' contains no text results", line.id)
                         continue
@@ -91,13 +101,13 @@ class KerasRate(Processor):
                         if level == 'word':
                             logger.debug("Getting text in word '%s'", word.id)
                             if not first_word:
-                                text.append(TextEquivType(Unicode=u' ')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                                text.append((None, [TextEquivType(Unicode=u' ')])) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
                             elif not first_line or not first_region:
-                                text.append(TextEquivType(Unicode=u'\n')) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                                text.append((None, [TextEquivType(Unicode=u'\n')])) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
                             first_word = False
                             textequivs = word.get_TextEquiv()
                             if textequivs:
-                                text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                                text.append((word, filter_choices(textequivs)))
                             else:
                                 logger.warn("Word '%s' contains no text results", word.id)
                             continue
@@ -117,7 +127,7 @@ class KerasRate(Processor):
                                                         Coords=CoordsType(points_from_xywh(xywh))) # empty box
                                 word.insert_Glyph_at(0, space_glyph) # add a pseudo glyph in annotation
                             else:
-                                text.append(space_textequiv) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
+                                text.append((None, [space_textequiv])) # LM output will not appear in annotation (conf cannot be combined to accurate perplexity from output)
                         glyphs = word.get_Glyph()
                         if not glyphs:
                             logger.warn("Word '%s' contains no glyphs", word.id)
@@ -125,28 +135,82 @@ class KerasRate(Processor):
                             logger.debug("Getting text in glyph '%s'", glyph.id)
                             textequivs = glyph.get_TextEquiv()
                             if textequivs:
-                                text.append(textequivs[0]) # only 1-best for now (otherwise we need to do beam search and return paths)
+                                text.append((glyph, filter_choices(textequivs)))
                             else:
                                 logger.warn("Glyph '%s' contains no text results", glyph.id)
                         first_word = False
                     first_line = False
                 first_region = False
-            textstring = u''.join(te.Unicode for te in text) # same length as text
-            logger.debug("Rating %d characters", len(textstring))
-            confidences = self.rater.rate_once(textstring)
-            avg = sum(confidences)/len(confidences)
-            ent = sum([-log(p, 2) for p in confidences])/len(confidences)
-            ppl = pow(2.0, ent) # character level
-            ppll = pow(2.0, ent * len(confidences)/len(text)) # textequiv level
-            logger.debug("avg: %.3f, char ppl: %.3f, %s ppl: %.3f", avg, ppl, level, ppll) # char need not always equal glyph!
-            i = 0
-            for textequiv in text:
-                j = len(textequiv.Unicode)
-                conf = sum(confidences[i:i+j])/j
-                textequiv.set_conf(conf) # or multiply to existing value?
-                i += j
-            if i != len(confidences):
-                logger.err("Input text length and output scores length are off by %d characters", i-len(confidences))
+            if self.parameter['alternative_decoding']:
+                logger.info("Rating %d elements including its alternatives", len(text))
+                # initial state; todo: pass from previous page
+                next_fringe = [lib.Node(parent=None, state=None, value=b'\n'[0], cost=0.0, extras=None)]
+                for element in text: # tuple of reference and list of its alternative textequivs
+                    logger.debug("Rating '%s', combining %d new inputs with %d existing paths", element[0].id if element[0] else "space", len(element[1]), len(next_fringe))
+                    fringe = next_fringe
+                    next_fringe = []
+                    for node in fringe:
+                        new_nodes = [lib.Node(parent=node, state=node.state, value=node.value, cost=0.0, extras=(element[0],textequiv.index)) for textequiv in element[1]] # copies of node (keeping value+state until prediction)
+                        alternatives = [textequiv.Unicode.encode("utf-8") for textequiv in element[1]] # byte sequences
+                        for i in range(MAX_ELEMENTS): # accumulate states and costs of all alternatives (of different length) in node
+                            updates = [j for j in range(len(element[1])) if i<len(alternatives[j])] # indices to update
+                            if updates == []:
+                                break
+                            preds, states = self.rater.rate_single([new_nodes[u].value for u in updates], [new_nodes[u].state for u in updates])
+                            for j, (new_node, alternative) in enumerate([(new_nodes[u], alternatives[u]) for u in updates]):
+                                new_node.value = alternative[i]
+                                new_node.state = states[j]
+                                new_node.cum_cost += -log(max(preds[j][new_node.value], 1e-99), 2)
+                        for new_node in new_nodes:
+                            insort_left(next_fringe, new_node) # insert sorted by cumulative costs
+                            # todo: incorporate input confidences, too (weighted product or as input into LM)
+                    # todo: history clustering for pruning paths by joining similar nodes (instead of neglecting costly nodes)
+                    #logger.debug("Shrinking %d paths to best %d", len(next_fringe), BEAM_WIDTH)
+                    next_fringe = next_fringe[:BEAM_WIDTH] # keep best paths (equals batch size)
+                best = next_fringe[0] # best-scoring path
+                best_len = 0
+                for node in best.to_sequence():
+                    if not node.parent:
+                        continue # ignore root node
+                    element = node.extras[0]
+                    if element: # not just space
+                        textequivs = element.get_TextEquiv()
+                        try:
+                            textequiv = next(te for te in textequivs if te.index == node.extras[1])
+                            element.set_TextEquiv([textequiv]) # delete others
+                            textequiv_len = len(textequiv.Unicode.encode("utf-8"))
+                            best_len += textequiv_len
+                            textequiv.set_conf(pow(2.0, -(node.cum_cost-node.parent.cum_cost)/textequiv_len)) # average probability
+                            #print(textequiv.Unicode, end='')
+                        except StopIteration:
+                            logger.err("TextEquiv index %d not found at element '%s'", node.extras[1], element.id)
+                    else:
+                        best_len += 1
+                        #print(bytes([node.value]).decode("utf-8"), end='')
+                #print('')
+                ent = best.cum_cost/best_len
+                avg = pow(2.0, -ent)
+                ppl = pow(2.0, ent) # byte level
+                ppll = pow(2.0, ent * best_len/best.length) # textequiv level (including spaces/newlines)
+                logger.info("avg: %.3f, byte ppl: %.3f, %s ppl: %.3f", avg, ppl, level, ppll) # byte need not always equal glyph!
+            else:
+                textstring = u''.join(node[1][0].Unicode for node in text) # same length as text
+                logger.info("Rating %d elements with a total of %d characters", len(text), len(textstring))
+                confidences = self.rater.rate_once(textstring)
+                i = 0
+                for node in text:
+                    textequiv = node[1][0] # 1st choice only
+                    j = len(textequiv.Unicode)
+                    conf = sum(confidences[i:i+j])/j
+                    textequiv.set_conf(conf) # todo: incorporate input confidences, too (weighted product or as input into LM)
+                    i += j
+                if i != len(confidences):
+                    logger.err("Input text length and output scores length are off by %d characters", i-len(confidences))
+                avg = sum(confidences)/len(confidences)
+                ent = sum([-log(max(p,1e-99), 2) for p in confidences])/len(confidences)
+                ppl = pow(2.0, ent) # character level
+                ppll = pow(2.0, ent * len(confidences)/len(text)) # textequiv level (including spaces/newlines)
+                logger.info("avg: %.3f, char ppl: %.3f, %s ppl: %.3f", avg, ppl, level, ppll) # char need not always equal glyph!
             ID = concat_padded(self.output_file_grp, n)
             self.workspace.add_file(
                 ID=ID,
@@ -155,3 +219,15 @@ class KerasRate(Processor):
                 mimetype=MIMETYPE_PAGE,
                 content=to_xml(pcgts),
             )
+
+def filter_choices(textequivs):
+    '''assuming `textequivs` are already sorted by input confidence (conf attribute), ensure maximum number and maximum relative threshold'''
+    textequivs = textequivs[:min(CHOICE_THRESHOLD_NUM,len(textequivs))]
+    if len(textequivs) > 0:
+        conf0 = textequivs[0].conf
+        if conf0:
+            return [te for te in textequivs if (conf0 - te.conf < CHOICE_THRESHOLD_CONF)]
+        else:
+            return textequivs
+    else:
+        return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ocrd >= 0.4.0
+ocrd >= 0.8.0
 click
 keras
 numpy

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest
+ocrd_tesserocr

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with codecs.open('README.md', encoding='utf-8') as f:
 
 setup(
     name='ocrd_keraslm',
-    version='0.0.1',
+    version='0.1.0',
     description='keras language model',
     long_description=README,
     author='Konstantin Baierer, Kay-Michael Würzner',
@@ -21,7 +21,7 @@ setup(
     license='Apache License 2.0',
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
-        'ocrd >= 0.4.0',
+        'ocrd >= 0.8.0',
         'keras',
         'click',
         'numpy',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with codecs.open('README.md', encoding='utf-8') as f:
 
 setup(
     name='ocrd_keraslm',
-    version='0.1.0',
+    version='0.2.0',
     description='keras language model',
     long_description=README,
     author='Konstantin Baierer, Kay-Michael Würzner',

--- a/test/prepare_gt.bash
+++ b/test/prepare_gt.bash
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -e -x
+
+CACHE_DIR=/tmp/ocrd_keraslm-cache
+TMP_DIR=$(mktemp -d -t ocrd_keraslm-tmp-XXXXXXXXXX)
+GT_FILES="kant_aufklaerung_1784 loeber_heuschrecken_1693"
+
+trap "rm -fr '$TMP_DIR'" ERR
+
+test ! -e "$1" # target directory must already exist
+
+test -d "$CACHE_DIR" || mkdir -p "$CACHE_DIR"
+
+for GT_FILE in $GT_FILES; do
+    test -f "$CACHE_DIR/$GT_FILE" ||
+        wget -P "$CACHE_DIR" http://www.deutsches-textarchiv.de/book/download_txt/$GT_FILE
+    sed -e '//d;/^[[].*[]]$/d' < "$CACHE_DIR/$GT_FILE" > "$TMP_DIR/${GT_FILE}.txt"
+done
+
+cat <<EOF > "$TMP_DIR/page-extract-imagefilename.xsl"
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15">
+  <!-- unfortunately, this totally depends on the exact namespace string, i.e. version -->
+  <!-- rid of xml syntax: -->  
+  <xsl:output
+      method="text"
+      standalone="yes"
+      omit-xml-declaration="yes"/>
+  <!-- get imageFilename attribute verbatim: -->  
+  <xsl:template match="pc:PcGts/pc:Page">
+    <xsl:value-of select="@imageFilename" disable-output-escaping="yes"/>
+    <xsl:apply-templates/>
+  </xsl:template>
+  <!-- override implicit rules copying elements and attributes: -->
+  <xsl:template match="text()"/>
+</xsl:stylesheet>
+EOF
+
+for GT_FILE in $GT_FILES; do
+    test -f "$CACHE_DIR/${GT_FILE}.zip" ||
+        wget -P "$CACHE_DIR" http://www.ocr-d.de/sites/all/GTDaten/${GT_FILE}.zip
+    unzip -d "$TMP_DIR" "$CACHE_DIR/${GT_FILE}.zip"
+    pushd "$TMP_DIR/$GT_FILE/$GT_FILE"
+    ocrd workspace init .
+    ZEROS=0000
+    i=0
+    for PAGE_FILE in page/*.xml; do
+        i=$((i+1))
+        ID=${ZEROS:0:$((4-${#i}))}$i
+        IMG_FILE=$(xsltproc "$TMP_DIR/page-extract-imagefilename.xsl" "$PAGE_FILE")
+        test -f "$IMG_FILE"
+        ocrd workspace add -G OCR-D-IMG -i OCR-D-IMG_$ID -g OCR-D-IMG_$ID -m image/tiff "$IMG_FILE"
+        ocrd workspace add -G OCR-D-GT-PAGE -i OCR-D-GT-PAGE_$ID -g OCR-D-IMG_$ID -m application/vnd.prima.page+xml "$PAGE_FILE"
+    done
+    popd
+done
+
+# this would break URIs:
+#mv "$TMP_DIR" "$1" # atomic
+# clone+cp instead:
+trap "rm -fr '$TMP_DIR' '$1'" ERR
+mkdir -p "$1"
+for GT_FILE in $GT_FILES; do # not so atomic
+    WORKSPACE="$TMP_DIR/$GT_FILE/$GT_FILE"
+    ocrd workspace clone -l "$WORKSPACE/mets.xml" "$1/$GT_FILE"
+    for PAGE_FILE in "$1/$GT_FILE/OCR-D-GT-PAGE/"*.xml; do # workaround for OCR-D/core issue #176
+        sed -ie "s|imageFilename=\"|imageFilename=\"file://$PWD/$1/$GT_FILE/OCR-D-IMG/|" "$PAGE_FILE"
+    done
+    cp "$TMP_DIR/${GT_FILE}.txt" "$1"
+done
+rm -fr "$TMP_DIR"
+
+

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -1,0 +1,103 @@
+import os, sys
+import shutil
+from unittest import TestCase, main
+
+from ocrd.resolver import Resolver
+from ocrd.model.ocrd_page import from_file, to_xml
+from ocrd import MIMETYPE_PAGE
+from ocrd_tesserocr.recognize import TesserocrRecognize
+from ocrd_keraslm.wrapper import KerasRate
+
+WORKSPACE_DIR = '/tmp/pyocrd-test-ocrd_keraslm'
+PWD = os.path.dirname(os.path.realpath(__file__))
+
+class TestKerasRate(TestCase):
+
+    def setUp(self):
+        if os.path.exists(WORKSPACE_DIR):
+            shutil.rmtree(WORKSPACE_DIR)
+        os.makedirs(WORKSPACE_DIR)
+
+    def runTest(self):
+        resolver = Resolver()
+        workspace = resolver.workspace_from_url('test/assets/kant_aufklaerung_1784/mets.xml', directory=WORKSPACE_DIR, download_local=True)
+        for file in workspace.mets.find_files(fileGrp='OCR-D-GT-PAGE'):
+            grp='OCR-D-GT-SEG-LINE'
+            ID=grp + '_' + file.ID.split(sep='_')[-1]
+            pcgts = from_file(file)
+            page = pcgts.get_Page()
+            for region in page.get_TextRegion():
+                for line in region.get_TextLine():
+                    line.set_TextEquiv([]) # remove text results (interferes with Tesserocr)
+                    line.set_Word([]) # remove word annotation (interferes with Tesserocr, has wrong tokenization)
+            workspace.add_file(
+                ID=ID,
+                file_grp=grp,
+                basename=ID + '.xml',
+                mimetype=MIMETYPE_PAGE,
+                content=to_xml(pcgts))
+        TesserocrRecognize(
+            workspace,
+            input_file_grp='OCR-D-GT-SEG-LINE',
+            output_file_grp='OCR-D-OCR-TESS-WORD',
+            parameter={'textequiv_level': 'word',
+                       'model': 'Fraktur'}
+            ).process()
+        workspace.save_mets()
+        KerasRate(
+            workspace,
+            input_file_grp='OCR-D-OCR-TESS-WORD',
+            output_file_grp='OCR-D-LM-WORD',
+            parameter={'textequiv_level': 'word',
+                       'alternative_decoding': False,
+                       'weight_file': PWD + '/../model_dta_test.weights.h5',
+                       'config_file': PWD + '/../model_dta_test.config.pkl'}
+            ).process()
+        workspace.save_mets()
+        workspace.reload_mets()
+        for file in workspace.mets.find_files(fileGrp='OCR-D-LM-WORD'):
+            continue # todo: for some reason, from_file yields NoneType here
+            pcgts = from_file(file)
+            metadata = pcgts.get_Metadata()
+            assertIsNotNone(metadata)
+            metadataitems = metadata.get_MetadataItem()
+            assertIsNotNone(metadataitems)
+            rated = any([i for i in metadataitems if i.get_value() == 'ocrd-keraslm-rate'])
+            assertTrue(rated)
+        TesserocrRecognize(
+            workspace,
+            input_file_grp='OCR-D-GT-SEG-LINE',
+            output_file_grp='OCR-D-OCR-TESS-GLYPH',
+            parameter={'textequiv_level': 'glyph',
+                       'model': 'deu-frak'}
+            ).process()
+        workspace.save_mets()
+        KerasRate(
+            workspace,
+            input_file_grp='OCR-D-OCR-TESS-GLYPH',
+            output_file_grp='OCR-D-LM-GLYPH',
+            parameter={'textequiv_level': 'glyph',
+                       'alternative_decoding': True,
+                       'beam_width': 10,
+                       'weight_file': PWD + '/../model_dta_test.weights.h5',
+                       'config_file': PWD + '/../model_dta_test.config.pkl'}
+            ).process()
+        workspace.save_mets()
+        workspace.reload_mets()
+        for file in workspace.mets.find_files(fileGrp='OCR-D-LM-GLYPH'):
+            continue # todo: for some reason, from_file yields NoneType here
+            pcgts = from_file(file)
+            metadata = pcgts.get_Metadata()
+            assertIsNotNone(metadata)
+            metadataitems = metadata.get_MetadataItem()
+            assertIsNotNone(metadataitems)
+            rated = any([i for i in metadataitems if i.get_value() == 'ocrd-keraslm-rate'])
+            assertTrue(rated)
+            for region in page.get_TextRegion():
+                for line in region.get_TextLine():
+                    for word in line.get_Word():
+                        for glyph in word.get_Glyph():
+                            assertEqual(len(glyph.get_TextEquiv()), 1) # only 1-best results
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I finally found a way to update the wrapper (integrating with PageXML), too – without relying on OCR-D/spec#72 (but also without any provisions to deal with alternatives yet). Both OCR-D/assets#12 and OCR-D/assets#13 are critical, though. (It does work with `ocrd-tesserocr-recognize` annotation, but not with current GT.)

Please see changelog for details. 

This works generally well on DTA plaintexts (after many weeks of GPU time searching for good parameters), giving perplexities around 5-7, depending on documents and centuries (as do 7-gram language models). More (better) models will be uploaded on [our provisional data repo](https://github.com/cisocrgroup/ocrd-data/tree/master/keraslm-models) soon.

@wrznr Sensible ways to better integrate this into the OCR-D workflow still have to be discussed, though. (Especially, rescoring alternatives or alternative paths to decode and return best paths.) Hierarchical data structures like XML are incapable of representing alternative sequences (history paths), be it for input (e.g. postcorrection candidates) or output (generative use of LM).